### PR TITLE
Feat/misc improvements

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "signal-hook",
  "test-utils",
  "tokio",
  "uuid",
@@ -1472,6 +1473,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -14,6 +14,7 @@ rocket = { version = "0.5.0", features = ["json", "uuid"] }
 rocket_db_pools = { version = "0.1.0", features = ["diesel_postgres" ]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+signal-hook = "0.3.17"
 tokio = { version = "1.37.0", features = ["test-util"] }
 uuid = { version = "1.8.0", features = ["v4", "serde", "fast-rng", "macro-diagnostics"] }
 

--- a/api/src/application/services/finish_job.rs
+++ b/api/src/application/services/finish_job.rs
@@ -41,7 +41,7 @@ impl<'a, T: Get<Monitor> + Save<Monitor>> FinishJobService<'a, T> {
 #[cfg(test)]
 mod tests {
     use rstest::*;
-    use tokio::test;
+    use tokio;
 
     use test_utils::{gen_relative_datetime, gen_uuid};
 
@@ -68,7 +68,7 @@ mod tests {
     }
 
     #[rstest]
-    #[test(start_paused = true)]
+    #[tokio::test(start_paused = true)]
     async fn test_finish_job_service(mut repo: TestRepository) {
         let monitor_before = repo
             .get(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"))

--- a/api/src/application/services/process_late_jobs.rs
+++ b/api/src/application/services/process_late_jobs.rs
@@ -36,7 +36,7 @@ impl<'a, Repo: GetWithLateJobs, Notifier: NotifyLateJob>
 #[cfg(test)]
 mod tests {
     use rstest::*;
-    use tokio::test;
+    use tokio;
     use uuid::Uuid;
 
     use test_utils::{gen_relative_datetime, gen_uuid};
@@ -136,7 +136,7 @@ mod tests {
     }
 
     #[rstest]
-    #[test(start_paused = true)]
+    #[tokio::test(start_paused = true)]
     async fn test_start_job_service(mut repo: TestRepository) {
         let mut notifier = FakeJobNotifier::new();
         let mut service = ProcessLateJobsService::new(&mut repo, &mut notifier);

--- a/api/src/application/services/update_monitor.rs
+++ b/api/src/application/services/update_monitor.rs
@@ -19,7 +19,6 @@ impl<'a, T: Get<Monitor> + Save<Monitor>> UpdateMonitorService<'a, T> {
         new_expected: i32,
         new_grace: i32,
     ) -> Option<Monitor> {
-        // TODO: Test me
         let mut monitor = self
             .repo
             .get(monitor_id)

--- a/api/src/domain/models/job.rs
+++ b/api/src/domain/models/job.rs
@@ -144,25 +144,25 @@ impl Serialize for Job {
 mod tests {
     use std::str::FromStr;
 
-    use rstest::rstest;
+    use chrono::Duration;
+    use rstest::*;
     use serde_json::{json, Value};
 
     use test_utils::{gen_datetime, gen_relative_datetime};
 
     use super::{Job, JobError, NaiveDateTime, Uuid};
 
-    // TODO: Figure out how to test the time-based elements. See https://tokio.rs/tokio/topics/testing
-
     #[test]
     fn starting_jobs() {
         let job = Job::start(300);
 
+        assert_eq!(job.max_end_time - job.start_time, Duration::seconds(300));
         assert_eq!(job.end_time, None);
         assert_eq!(job.succeeded, None);
         assert_eq!(job.output, None);
 
         // New jobs should always be in progress.
-        assert!(job.in_progress())
+        assert!(job.in_progress());
     }
 
     #[test]
@@ -172,6 +172,7 @@ mod tests {
         let result1 = job.finish(true, None);
         assert!(result1.is_ok());
         assert_eq!(job.in_progress(), false);
+        assert!(job.end_time.is_some());
         assert_eq!(job.succeeded, Some(true));
         assert_eq!(job.output, None);
 

--- a/api/src/domain/models/monitor.rs
+++ b/api/src/domain/models/monitor.rs
@@ -117,12 +117,13 @@ impl Monitor {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
 
-    use chrono::{offset::Utc, NaiveDateTime};
+    use chrono::NaiveDateTime;
     use rstest::rstest;
 
-    use super::{Duration, Job, JobError, Monitor, Uuid};
+    use test_utils::{gen_relative_datetime, gen_uuid};
+
+    use super::{Job, JobError, Monitor, Uuid};
 
     #[test]
     fn creating_new_monitors() {
@@ -139,14 +140,10 @@ mod tests {
     #[case(
         vec![
             (
-                // TODO: We do a lot of this in tests - find a nice way to extract this into a
-                // helper function.
-                Uuid::from_str("79192674-0e87-4f79-b988-0efd5ae76420").unwrap(),
-                Utc::now().naive_utc() + Duration::seconds(5)
+                gen_uuid("79192674-0e87-4f79-b988-0efd5ae76420"), gen_relative_datetime(5)
             ),
             (
-                Uuid::from_str("15904641-2d0e-4d27-8fd0-b130f0ab5aa9").unwrap(),
-                Utc::now().naive_utc() + Duration::seconds(5)
+                gen_uuid("15904641-2d0e-4d27-8fd0-b130f0ab5aa9"), gen_relative_datetime(5)
             )
         ],
         vec![]
@@ -154,30 +151,26 @@ mod tests {
     #[case(
         vec![
             (
-                Uuid::from_str("79192674-0e87-4f79-b988-0efd5ae76420").unwrap(),
-                Utc::now().naive_utc()
+                gen_uuid("79192674-0e87-4f79-b988-0efd5ae76420"), gen_relative_datetime(0)
             ),
             (
-                Uuid::from_str("15904641-2d0e-4d27-8fd0-b130f0ab5aa9").unwrap(),
-                Utc::now().naive_utc() + Duration::seconds(5)
+                gen_uuid("15904641-2d0e-4d27-8fd0-b130f0ab5aa9"), gen_relative_datetime(5)
             )
         ],
-        vec![Uuid::from_str("79192674-0e87-4f79-b988-0efd5ae76420").unwrap()]
+        vec![gen_uuid("79192674-0e87-4f79-b988-0efd5ae76420")]
     )]
     #[case(
         vec![
             (
-                Uuid::from_str("79192674-0e87-4f79-b988-0efd5ae76420").unwrap(),
-                Utc::now().naive_utc()
+                gen_uuid("79192674-0e87-4f79-b988-0efd5ae76420"), gen_relative_datetime(0)
             ),
             (
-                Uuid::from_str("15904641-2d0e-4d27-8fd0-b130f0ab5aa9").unwrap(),
-                Utc::now().naive_utc()
+                gen_uuid("15904641-2d0e-4d27-8fd0-b130f0ab5aa9"), gen_relative_datetime(0)
             )
         ],
         vec![
-            Uuid::from_str("79192674-0e87-4f79-b988-0efd5ae76420").unwrap(),
-            Uuid::from_str("15904641-2d0e-4d27-8fd0-b130f0ab5aa9").unwrap()
+            gen_uuid("79192674-0e87-4f79-b988-0efd5ae76420"),
+            gen_uuid("15904641-2d0e-4d27-8fd0-b130f0ab5aa9")
         ]
     )]
     fn checking_for_late_jobs(
@@ -189,9 +182,7 @@ mod tests {
             .iter()
             .map(|i| Job {
                 job_id: i.0,
-                // TODO: We do a lot of this in tests - find a nice way to extract this into a
-                // helper function.
-                start_time: Utc::now().naive_utc() - Duration::seconds(200),
+                start_time: gen_relative_datetime(-200),
                 max_end_time: i.1,
                 end_time: None,
                 succeeded: None,
@@ -208,26 +199,26 @@ mod tests {
         let mut mon = Monitor::new("new-monitor".to_owned(), 200, 100);
         mon.jobs = vec![
             Job {
-                job_id: Uuid::from_str("70e7f11b-7ae3-4e69-adb0-52fdbf775ee1").unwrap(),
-                start_time: Utc::now().naive_utc(),
-                max_end_time: Utc::now().naive_utc() + Duration::seconds(300),
+                job_id: gen_uuid("70e7f11b-7ae3-4e69-adb0-52fdbf775ee1"),
+                start_time: gen_relative_datetime(0),
+                max_end_time: gen_relative_datetime(300),
                 end_time: None,
                 succeeded: None,
                 output: None,
             },
             Job {
-                job_id: Uuid::from_str("139fbf11-eff1-44cf-9f58-b5febb4729d6").unwrap(),
-                start_time: Utc::now().naive_utc() - Duration::seconds(200),
-                max_end_time: Utc::now().naive_utc() + Duration::seconds(100),
-                end_time: Some(Utc::now().naive_utc()),
+                job_id: gen_uuid("139fbf11-eff1-44cf-9f58-b5febb4729d6"),
+                start_time: gen_relative_datetime(-200),
+                max_end_time: gen_relative_datetime(100),
+                end_time: Some(gen_relative_datetime(0)),
                 succeeded: Some(true),
                 output: None,
             },
             Job {
-                job_id: Uuid::from_str("a4a8d5ac-86c1-448d-aa82-3388d59ac43e").unwrap(),
-                start_time: Utc::now().naive_utc() - Duration::seconds(300),
-                max_end_time: Utc::now().naive_utc(),
-                end_time: Some(Utc::now().naive_utc() - Duration::seconds(50)),
+                job_id: gen_uuid("a4a8d5ac-86c1-448d-aa82-3388d59ac43e"),
+                start_time: gen_relative_datetime(-300),
+                max_end_time: gen_relative_datetime(0),
+                end_time: Some(gen_relative_datetime(-50)),
                 succeeded: Some(false),
                 output: None,
             },
@@ -236,7 +227,7 @@ mod tests {
         let last_finished_job = mon.last_finished_job().unwrap();
         assert_eq!(
             last_finished_job.job_id,
-            Uuid::from_str("139fbf11-eff1-44cf-9f58-b5febb4729d6").unwrap()
+            gen_uuid("139fbf11-eff1-44cf-9f58-b5febb4729d6")
         );
     }
 
@@ -245,25 +236,25 @@ mod tests {
         let mut mon = Monitor::new("new-monitor".to_owned(), 200, 100);
         mon.jobs = vec![
             Job {
-                job_id: Uuid::from_str("70e7f11b-7ae3-4e69-adb0-52fdbf775ee1").unwrap(),
-                start_time: Utc::now().naive_utc(),
-                max_end_time: Utc::now().naive_utc() + Duration::seconds(300),
+                job_id: gen_uuid("70e7f11b-7ae3-4e69-adb0-52fdbf775ee1"),
+                start_time: gen_relative_datetime(0),
+                max_end_time: gen_relative_datetime(300),
                 end_time: None,
                 succeeded: None,
                 output: None,
             },
             Job {
-                job_id: Uuid::from_str("139fbf11-eff1-44cf-9f58-b5febb4729d6").unwrap(),
-                start_time: Utc::now().naive_utc() - Duration::seconds(200),
-                max_end_time: Utc::now().naive_utc() + Duration::seconds(100),
+                job_id: gen_uuid("139fbf11-eff1-44cf-9f58-b5febb4729d6"),
+                start_time: gen_relative_datetime(-200),
+                max_end_time: gen_relative_datetime(100),
                 end_time: None,
                 succeeded: None,
                 output: None,
             },
             Job {
-                job_id: Uuid::from_str("a4a8d5ac-86c1-448d-aa82-3388d59ac43e").unwrap(),
-                start_time: Utc::now().naive_utc() - Duration::seconds(300),
-                max_end_time: Utc::now().naive_utc(),
+                job_id: gen_uuid("a4a8d5ac-86c1-448d-aa82-3388d59ac43e"),
+                start_time: gen_relative_datetime(-300),
+                max_end_time: gen_relative_datetime(0),
                 end_time: None,
                 succeeded: None,
                 output: None,
@@ -279,25 +270,25 @@ mod tests {
         let mut mon = Monitor::new("new-monitor".to_owned(), 200, 100);
         mon.jobs = vec![
             Job {
-                job_id: Uuid::from_str("70e7f11b-7ae3-4e69-adb0-52fdbf775ee1").unwrap(),
-                start_time: Utc::now().naive_utc(),
-                max_end_time: Utc::now().naive_utc() + Duration::seconds(300),
+                job_id: gen_uuid("70e7f11b-7ae3-4e69-adb0-52fdbf775ee1"),
+                start_time: gen_relative_datetime(0),
+                max_end_time: gen_relative_datetime(300),
                 end_time: None,
                 succeeded: None,
                 output: None,
             },
             Job {
-                job_id: Uuid::from_str("139fbf11-eff1-44cf-9f58-b5febb4729d6").unwrap(),
-                start_time: Utc::now().naive_utc() - Duration::seconds(200),
-                max_end_time: Utc::now().naive_utc() + Duration::seconds(100),
+                job_id: gen_uuid("139fbf11-eff1-44cf-9f58-b5febb4729d6"),
+                start_time: gen_relative_datetime(-200),
+                max_end_time: gen_relative_datetime(100),
                 end_time: None,
                 succeeded: None,
                 output: None,
             },
             Job {
-                job_id: Uuid::from_str("a4a8d5ac-86c1-448d-aa82-3388d59ac43e").unwrap(),
-                start_time: Utc::now().naive_utc() - Duration::seconds(300),
-                max_end_time: Utc::now().naive_utc(),
+                job_id: gen_uuid("a4a8d5ac-86c1-448d-aa82-3388d59ac43e"),
+                start_time: gen_relative_datetime(-300),
+                max_end_time: gen_relative_datetime(0),
                 end_time: None,
                 succeeded: None,
                 output: None,
@@ -307,7 +298,7 @@ mod tests {
         let last_started_job = mon.last_started_job().unwrap();
         assert_eq!(
             last_started_job.job_id,
-            Uuid::from_str("70e7f11b-7ae3-4e69-adb0-52fdbf775ee1").unwrap()
+            gen_uuid("70e7f11b-7ae3-4e69-adb0-52fdbf775ee1")
         );
     }
 

--- a/api/src/infrastructure/cors.rs
+++ b/api/src/infrastructure/cors.rs
@@ -7,7 +7,6 @@ pub struct CORS;
 
 #[async_trait]
 impl Fairing for CORS {
-    // TODO: Test me
     fn info(&self) -> Info {
         Info {
             name: "CORS headers in responses",

--- a/api/src/infrastructure/models/job.rs
+++ b/api/src/infrastructure/models/job.rs
@@ -33,3 +33,34 @@ impl Into<Job> for &JobData {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use test_utils::{gen_datetime, gen_uuid};
+
+    use super::{Job, JobData};
+
+    #[test]
+    fn test_job_data_into_job() {
+        let job_data = JobData {
+            job_id: gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
+            start_time: gen_datetime("2024-04-22T22:43:00"),
+            max_end_time: gen_datetime("2024-04-22T22:53:00"),
+            end_time: Some(gen_datetime("2024-04-22T22:50:00")),
+            succeeded: Some(true),
+            output: Some(String::from("Job completed successfully")),
+            monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+        };
+
+        let job: Job = (&job_data).into();
+
+        assert_eq!(job.job_id, gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"));
+        assert_eq!(job.start_time, gen_datetime("2024-04-22T22:43:00"));
+        assert_eq!(job.max_end_time, gen_datetime("2024-04-22T22:53:00"));
+        assert_eq!(job.end_time, Some(gen_datetime("2024-04-22T22:50:00")));
+        assert_eq!(job.succeeded, Some(true));
+        assert_eq!(job.output, Some(String::from("Job completed successfully")));
+    }
+}

--- a/api/src/infrastructure/models/monitor.rs
+++ b/api/src/infrastructure/models/monitor.rs
@@ -18,7 +18,6 @@ pub struct MonitorData {
 
 impl Into<Monitor> for (&MonitorData, &Vec<JobData>) {
     fn into(self) -> Monitor {
-        // TODO: Test me
         Monitor {
             monitor_id: self.0.monitor_id,
             name: self.0.name.clone(),
@@ -31,7 +30,6 @@ impl Into<Monitor> for (&MonitorData, &Vec<JobData>) {
 
 impl From<&Monitor> for (MonitorData, Vec<JobData>) {
     fn from(value: &Monitor) -> Self {
-        // TODO: Test me
         (
             MonitorData {
                 monitor_id: value.monitor_id,
@@ -53,5 +51,96 @@ impl From<&Monitor> for (MonitorData, Vec<JobData>) {
                 })
                 .collect(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use test_utils::{gen_datetime, gen_uuid};
+
+    use crate::domain::models::job::Job;
+
+    use super::{JobData, Monitor, MonitorData};
+
+    #[test]
+    fn test_monitor_to_db_data() {
+        let monitor = Monitor {
+            monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+            name: "foo".to_owned(),
+            expected_duration: 300,
+            grace_duration: 100,
+            jobs: vec![Job::new(
+                gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
+                gen_datetime("2024-04-22T22:43:00"),
+                gen_datetime("2024-04-22T22:53:00"),
+                None,
+                None,
+                None,
+            )],
+        };
+
+        let (monitor_data, job_data) = <(MonitorData, Vec<JobData>)>::from(&monitor);
+
+        assert_eq!(monitor_data.monitor_id, monitor.monitor_id);
+        assert_eq!(monitor_data.name, monitor.name);
+        assert_eq!(monitor_data.expected_duration, monitor.expected_duration);
+        assert_eq!(monitor_data.grace_duration, monitor.grace_duration);
+
+        assert_eq!(job_data.len(), 1);
+        let job_data = &job_data[0];
+        assert_eq!(
+            job_data.job_id,
+            gen_uuid("01a92c6c-6803-409d-b675-022fff62575a")
+        );
+        assert_eq!(
+            job_data.monitor_id,
+            gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")
+        );
+        assert_eq!(job_data.start_time, gen_datetime("2024-04-22T22:43:00"));
+        assert_eq!(job_data.max_end_time, gen_datetime("2024-04-22T22:53:00"));
+        assert_eq!(job_data.end_time, None);
+        assert_eq!(job_data.succeeded, None);
+        assert_eq!(job_data.output, None);
+    }
+
+    #[test]
+    fn test_converting_db_to_monitor() {
+        let monitor_data = MonitorData {
+            monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+            name: "foo".to_owned(),
+            expected_duration: 300,
+            grace_duration: 100,
+        };
+
+        let job_data = vec![JobData {
+            job_id: gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
+            monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+            start_time: gen_datetime("2024-04-22T22:43:00"),
+            max_end_time: gen_datetime("2024-04-22T22:53:00"),
+            end_time: None,
+            succeeded: None,
+            output: None,
+        }];
+
+        let monitor: Monitor = (&monitor_data, &job_data).into();
+
+        assert_eq!(
+            monitor.monitor_id,
+            gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")
+        );
+        assert_eq!(monitor.name, "foo".to_owned());
+        assert_eq!(monitor.expected_duration, 300);
+        assert_eq!(monitor.grace_duration, 100);
+
+        assert_eq!(monitor.jobs.len(), 1);
+        let job = &monitor.jobs[0];
+        assert_eq!(job.job_id, gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"));
+        assert_eq!(job.start_time, gen_datetime("2024-04-22T22:43:00"));
+        assert_eq!(job.max_end_time, gen_datetime("2024-04-22T22:53:00"));
+        assert_eq!(job.end_time, None);
+        assert_eq!(job.succeeded, None);
+        assert_eq!(job.output, None);
     }
 }

--- a/api/src/infrastructure/repositories/monitor_repo.rs
+++ b/api/src/infrastructure/repositories/monitor_repo.rs
@@ -98,7 +98,6 @@ impl<'a> Get<Monitor> for MonitorRepository<'a> {
                 .order(job::start_time.desc())
                 .load(self.db)
                 .await?;
-            // TODO handle monitors without jobs.
             Ok(Some(self.db_to_monitor(monitor, jobs)))
         } else {
             Ok(None)

--- a/api/src/infrastructure/repositories/monitor_repo.rs
+++ b/api/src/infrastructure/repositories/monitor_repo.rs
@@ -166,7 +166,8 @@ impl<'a> Save<Monitor> for MonitorRepository<'a> {
 
                         let job_ids = &cached.1.iter().map(|j| j.job_id).collect::<Vec<Uuid>>();
                         for j in &job_datas {
-                            // TODO: Handle jobs being deleted.
+                            // TODO: Handle jobs being deleted. Don't need to worry about this for
+                            // now since there isn't anything that deletes jobs within monitors.
                             if job_ids.contains(&j.job_id) {
                                 diesel::update(j).set(j).execute(conn).await?;
                             } else {

--- a/api/tests/monitor_repo_test.rs
+++ b/api/tests/monitor_repo_test.rs
@@ -1,7 +1,5 @@
 pub mod common;
 
-use std::str::FromStr;
-
 use pretty_assertions::assert_eq;
 use tokio::test;
 use uuid::Uuid;
@@ -57,11 +55,11 @@ async fn test_get() {
     let mut repo = MonitorRepository::new(&mut conn);
 
     let should_be_none = repo
-        .get(Uuid::from_str("4940ede2-72fc-4e0e-838e-f15f35e3594f").unwrap())
+        .get(gen_uuid("4940ede2-72fc-4e0e-838e-f15f35e3594f"))
         .await
         .unwrap();
     let should_be_some = repo
-        .get(Uuid::from_str("c1bf0515-df39-448b-aa95-686360a33b36").unwrap())
+        .get(gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"))
         .await
         .unwrap();
 
@@ -118,7 +116,7 @@ async fn test_delete() {
     let mut repo = MonitorRepository::new(&mut conn);
 
     let monitor = repo
-        .get(Uuid::from_str("c1bf0515-df39-448b-aa95-686360a33b36").unwrap())
+        .get(gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"))
         .await
         .unwrap()
         .unwrap();


### PR DESCRIPTION
Numerous miscellaneous improvements, namely:

* Use internal `test-utils` crate wherever possible.
* Add some missing test coverage.
* Simplify how we query for `Monitor`s with late `Job`s, going from three queries to two.
* Use transactions for `Monitor` queries.
* Handle `SIGINT` in a bit of a nicer way in the monitoring service.