### PR TITLE
Build/prod builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
   "name": "CronMon Dev Container",
   "build": {
     "dockerfile": "../Dockerfile",
-    "context": ".."
+    "context": "..",
+    "target": "builder"
   },
   "containerEnv": {
     "RUST_BACKTRACE": "full",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
   "containerEnv": {
     "RUST_BACKTRACE": "full",
     "DATABASE_URL": "postgres://cron-mon-api:itsasecret@host.docker.internal:54320/cron-mon",
-    "DOCS_DIR": "/usr/cron-mon/api/docs",
     "ROCKET_PROFILE": "vscode"
   },
   "runArgs": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,5 +85,4 @@ jobs:
         run: cd api && cargo test --no-fail-fast --test "*" -- --test-threads=1
         env:
           DATABASE_URL: postgres://cron-mon-api:itsasecret@cron-mon-db/cron-mon
-          DOCS_DIR: ${{ github.workspace }}/api/docs
           ROCKET_PROFILE: github

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,11 +11,12 @@
             "program": "${workspaceFolder}/api/target/debug/api",
             "args": [],
             "cwd": "${workspaceFolder}/api",
-            "initCommands":["settings set target.disable-aslr false"],
+            "initCommands": [
+                "settings set target.disable-aslr false"
+            ],
             "env": {
                 "RUST_BACKTRACE": "full",
                 "DATABASE_URL": "postgres://cron-mon-api:itsasecret@host.docker.internal:54320/cron-mon",
-                "DOCS_DIR": "/usr/cron-mon/api/docs",
                 "ROCKET_PROFILE": "vscode"
             }
         }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/docker/library/rust:1.79.0-slim as builder
 
-RUN apt-get update && apt-get install libpq-dev -y
+RUN apt-get update && apt-get install build-essential libpq-dev -y
 RUN rustup component add rustfmt
 RUN cargo install diesel_cli --no-default-features --features postgres
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/rust:1.79.0-slim
+FROM public.ecr.aws/docker/library/rust:1.79.0-slim as builder
 
 RUN apt-get update && apt-get install libpq-dev -y
 RUN rustup component add rustfmt
@@ -7,3 +7,32 @@ RUN cargo install diesel_cli --no-default-features --features postgres
 WORKDIR /usr/cron-mon/api
 
 COPY ./api .
+
+RUN cargo build --release
+
+FROM public.ecr.aws/docker/library/debian:bookworm-slim
+
+# Set up a non-root user and directory
+RUN groupadd -g 1000 cron-mon && \
+    useradd -r -u 1000 -g cron-mon cron-mon && \
+    mkdir /usr/bin/cron-mon && chown cron-mon:cron-mon /usr/bin/cron-mon
+WORKDIR /usr/bin/cron-mon
+
+COPY --from=builder \
+    --chown=cron-mon:cron-mon \
+    /usr/cron-mon/api/diesel.toml /usr/bin/cron-mon/diesel.toml
+COPY --from=builder \
+    --chown=cron-mon:cron-mon \
+    /usr/cron-mon/api/Rocket.toml /usr/bin/cron-mon/Rocket.toml
+COPY --from=builder \
+    --chown=cron-mon:cron-mon \
+    /usr/cron-mon/api/docs /usr/bin/cron-mon/docs
+
+COPY --from=builder \
+    --chown=cron-mon:cron-mon \
+    /usr/cron-mon/api/target/release/api /usr/bin/cron-mon/api
+COPY --from=builder \
+    --chown=cron-mon:cron-mon \
+    /usr/cron-mon/api/target/release/monitor /usr/bin/cron-mon/monitor
+
+USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN groupadd -g 1000 cron-mon && \
     mkdir /usr/bin/cron-mon && chown cron-mon:cron-mon /usr/bin/cron-mon
 WORKDIR /usr/bin/cron-mon
 
+RUN apt-get update && apt-get install libpq-dev -y
+
 COPY --from=builder \
     --chown=cron-mon:cron-mon \
     /usr/cron-mon/api/diesel.toml /usr/bin/cron-mon/diesel.toml

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,17 @@ build-containers:
 run:
 	docker compose up api
 
+run-debug:
+	docker compose up api-debug
+
 run-monitor:
 	docker compose up monitor
 
+run-monitor-debug:
+	docker compose up monitor-debug
+
 test:
-	docker compose run --rm --no-deps api bash -c 'cargo test --lib --no-fail-fast'
+	docker compose run --rm --no-deps api-debug bash -c 'cargo test --lib --no-fail-fast'
 
 # Note that running this locally will re-seed your local DB so you'll lose
 # everything in there currently.

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ migration:
 migrate:
 	docker compose run --rm rust-cargo diesel migration run
 
+migrate-revert:
+	docker compose run --rm rust-cargo diesel migration revert
+
 migrate-redo:
 	docker compose run --rm rust-cargo diesel migration redo
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ run-monitor-debug:
 	docker compose up monitor-debug
 
 test:
-	docker compose run --rm --no-deps api-debug bash -c 'cargo test --lib --no-fail-fast'
+	docker compose run --rm --no-deps rust-cargo bash -c 'cargo test --lib --no-fail-fast'
 
 # Note that running this locally will re-seed your local DB so you'll lose
 # everything in there currently.
@@ -24,13 +24,13 @@ integration-tests:
 	docker compose up integration-tests-rs
 
 migration:
-	docker compose run --rm api-debug diesel migration generate $(name)
+	docker compose run --rm rust-cargo diesel migration generate $(name)
 
 migrate:
-	docker compose run --rm api-debug diesel migration run
+	docker compose run --rm rust-cargo diesel migration run
 
 migrate-redo:
-	docker compose run --rm api-debug diesel migration redo
+	docker compose run --rm rust-cargo diesel migration redo
 
 seed:
 	docker compose run --rm seeder

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ migration:
 	docker compose run --rm api-debug diesel migration generate $(name)
 
 migrate:
-	docker compose run --rm api diesel migration run
+	docker compose run --rm api-debug diesel migration run
 
 migrate-redo:
-	docker compose run --rm api diesel migration redo
+	docker compose run --rm api-debug diesel migration redo
 
 seed:
 	docker compose run --rm seeder

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ integration-tests:
 	docker compose up integration-tests-rs
 
 migration:
-	docker compose run --rm api diesel migration generate $(name)
+	docker compose run --rm api-debug diesel migration generate $(name)
 
 migrate:
 	docker compose run --rm api diesel migration run

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ migrate-redo:
 seed:
 	docker compose run --rm seeder
 
+shell:
+	docker compose run --rm rust-cargo bash
+
 
 # Can't delete the volume when PostgreSQL is running.
 delete-postgres-volume:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ reliable debug configuration (this is tried and tested on Visual Studio Code).
   write the actual migration scripts within the generated `up.sql` and `down.sql` files in the
   generated migration.
 - `migrate`: Run any migrations that haven't been applied to the local database.
+- `migrate-revert`: Downgrade the latest migration on the local database.
 - `migrate-redo`: Downgrade and then re apply the latest migration on the local database.
 - `seed`: Remove all data from the local database and insert the test data (this is the same test
   data that get's written to the local database during `make install`).

--- a/README.md
+++ b/README.md
@@ -64,11 +64,28 @@ A [Development container](https://containers.dev/) configuration file is also pr
 your IDE can use your local containers' environments and to provide a pre-setup, consistent and
 reliable debug configuration (this is tried and tested on Visual Studio Code).
 
-### Makefile
+### Makefiles
+
+There are two `Makefile`s provided to make local development a bit easier; one at the root of the
+project, intended to be ran on your host machine, running through Docker; and another within `/api`,
+intended to be ran within the application container of development container.
+
+Both `Makefile`s have mostly the same commands, with the exception of the following commands that
+only the root-level `Makefile` has:
 
 - `install`: Builds all application containers, installs the required Node modules in the Vue
   application and sets up a local PostgreSQL database with test data.
 - `build-containers`: Builds all application containers.
+- `seed`: Remove all data from the local database and insert the test data (this is the same test
+  data that get's written to the local database during `make install`).
+- `shell`: Open a `bash` shell on the application container, where you can use the _other_
+  `Makefile` to run commands without the overhead of spinning up containers for each command.
+- `delete-postgres-volume`: Remove the Docker volume being used to make PostgreSQL data persist.
+  This can be handy is you run into any problems with your local database and you just want to trash
+  it and start again. The next time the database container runs this will be recreated naturally
+
+The following commands are present in both `Makefile`s:
+
 - `run`: Run the CronMon API (release build).
 - `run-debug` Run a debug build of the CronMon API.
 - `run-monitor`: Run the CronMon monitoring service (release build).
@@ -83,11 +100,6 @@ reliable debug configuration (this is tried and tested on Visual Studio Code).
 - `migrate`: Run any migrations that haven't been applied to the local database.
 - `migrate-revert`: Downgrade the latest migration on the local database.
 - `migrate-redo`: Downgrade and then re apply the latest migration on the local database.
-- `seed`: Remove all data from the local database and insert the test data (this is the same test
-  data that get's written to the local database during `make install`).
-- `delete-postgres-volume`: Remove the Docker volume being used to make PostgreSQL data persist.
-  This can be handy is you run into any problems with your local database and you just want to trash
-  it and start again. The next time the database container runs this will be recreated naturally
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ reliable debug configuration (this is tried and tested on Visual Studio Code).
 - `install`: Builds all application containers, installs the required Node modules in the Vue
   application and sets up a local PostgreSQL database with test data.
 - `build-containers`: Builds all application containers.
-- `run`: Run the CronMon API
-- `run-monitor`: Run the CronMon monitoring service.
+- `run`: Run the CronMon API (release build).
+- `run-debug` Run a debug build of the CronMon API.
+- `run-monitor`: Run the CronMon monitoring service (release build).
+- `run-monitor-debug`: Run a debug build of the CronMon monitoring service.
 - `test`: Run all units tests.
 - `integration-tests`: Run the **integration** tests (note that this will remove whatever's in your
   local database, and as such these tests will never run unless they're invoked via this command).

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "chrono",
  "diesel",
  "diesel-async",
+ "diesel_migrations",
  "pretty_assertions",
  "rocket",
  "rocket_db_pools",
@@ -356,6 +357,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel_migrations"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
+dependencies = [
+ "diesel",
+ "migrations_internals",
+ "migrations_macros",
+]
+
+[[package]]
 name = "diesel_table_macro_syntax"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,7 +445,7 @@ dependencies = [
  "atomic 0.6.0",
  "pear",
  "serde",
- "toml",
+ "toml 0.8.14",
  "uncased",
  "version_check",
 ]
@@ -833,6 +845,27 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "migrations_internals"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
+dependencies = [
+ "serde",
+ "toml 0.7.8",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "mime"
@@ -1757,6 +1790,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
@@ -1774,6 +1819,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.5.40",
 ]
 
 [[package]]

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "chrono",
  "diesel_derives",
  "itoa",
+ "pq-sys",
  "uuid",
 ]
 
@@ -1090,6 +1091,15 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pq-sys"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c0052426df997c0cbd30789eb44ca097e3541717a7b8fa36b1c464ee7edebd"
+dependencies = [
+ "vcpkg",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -2017,6 +2027,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = "0.1.80"
 chrono = { version = "0.4", features = ["serde"]}
 diesel = { version = "2.1.6", features = ["chrono", "uuid"] }
 diesel-async = { version = "0.4.1", features = ["postgres"] }
+diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 rocket = { version = "0.5.1", features = ["json", "uuid"] }
 rocket_db_pools = { version = "0.2.0", features = ["diesel_postgres" ]}
 serde = { version = "1.0", features = ["derive"] }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.80"
 chrono = { version = "0.4", features = ["serde"]}
-diesel = { version = "2.1.6", features = ["chrono", "uuid"] }
+diesel = { version = "2.1.6", features = ["chrono", "uuid", "postgres"] }
 diesel-async = { version = "0.4.1", features = ["postgres"] }
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 rocket = { version = "0.5.1", features = ["json", "uuid"] }

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,0 +1,31 @@
+# This Makefile runs the commands directly on the host as it's expected to be used on
+# the application container or development container, purely to speed up local
+# development a bit. Note that if you want to run a release build of the API on
+# monitoring microservice, then you should use the Makefile at the root of this
+# project on your host machine.
+
+run-debug:
+	cargo run --bin api
+
+run-monitor-debug:
+	cargo run --bin monitor
+
+test:
+	cargo test --lib --no-fail-fast
+
+# Note that running this locally will re-seed your local DB so you'll lose
+# everything in there currently.
+integration-tests:
+	cargo test --no-fail-fast --test "*" -- --test-threads=1
+
+migration:
+	diesel migration generate $(name)
+
+migrate:
+	diesel migration run
+
+migrate-revert:
+	diesel migration revert
+
+migrate-redo:
+	diesel migration redo

--- a/api/Rocket.toml
+++ b/api/Rocket.toml
@@ -11,5 +11,8 @@ ident = "Cron Mon API - GitHub Actions"
 [default.databases.monitors]
 url = "postgres://cron-mon-api:itsasecret@cron-mon-db/cron-mon"
 
+[release.databases.monitors]
+url = "postgres://cron-mon-api:itsasecret@host.docker.internal:54320/cron-mon"
+
 [vscode.databases.monitors]
 url = "postgres://cron-mon-api:itsasecret@host.docker.internal:54320/cron-mon"

--- a/api/Rocket.toml
+++ b/api/Rocket.toml
@@ -1,9 +1,13 @@
 [default]
 address = "0.0.0.0"
 ident = "Cron Mon API"
+log_level = "normal"
 
 [debug]
 ident = "Cron Mon API - debug"
+
+[release]
+ident = "Cron Mon API (prod)"
 
 [github]
 ident = "Cron Mon API - GitHub Actions"

--- a/api/Rocket.toml
+++ b/api/Rocket.toml
@@ -11,12 +11,3 @@ ident = "Cron Mon API (prod)"
 
 [github]
 ident = "Cron Mon API - GitHub Actions"
-
-[default.databases.monitors]
-url = "postgres://cron-mon-api:itsasecret@cron-mon-db/cron-mon"
-
-[release.databases.monitors]
-url = "postgres://cron-mon-api:itsasecret@host.docker.internal:54320/cron-mon"
-
-[vscode.databases.monitors]
-url = "postgres://cron-mon-api:itsasecret@host.docker.internal:54320/cron-mon"

--- a/api/build.rs
+++ b/api/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/infrastructure/migrations");
+}

--- a/api/src/infrastructure/database.rs
+++ b/api/src/infrastructure/database.rs
@@ -9,7 +9,7 @@ use rocket_db_pools::{diesel, Database};
 pub struct Db(diesel::PgPool);
 
 pub async fn establish_connection() -> AsyncPgConnection {
-    let database_url = env::var("DATABASE_URL").expect("No DATABASE_URL");
+    let database_url = env::var("DATABASE_URL").expect("'DATABASE_URL' missing from environment");
     AsyncPgConnection::establish(&database_url)
         .unwrap_or_else(|_| panic!("Failed to establish DB connection"))
         .await

--- a/api/src/infrastructure/database.rs
+++ b/api/src/infrastructure/database.rs
@@ -1,6 +1,9 @@
 use std::env;
 
+use ::diesel::Connection;
+use diesel::PgConnection;
 use diesel_async::{AsyncConnection, AsyncPgConnection};
+use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use rocket::futures::TryFutureExt;
 use rocket_db_pools::{diesel, Database};
 
@@ -8,9 +11,24 @@ use rocket_db_pools::{diesel, Database};
 #[database("monitors")]
 pub struct Db(diesel::PgPool);
 
+const MIGRATIONS: EmbeddedMigrations = embed_migrations!("src/infrastructure/migrations");
+
 pub async fn establish_connection() -> AsyncPgConnection {
-    let database_url = env::var("DATABASE_URL").expect("'DATABASE_URL' missing from environment");
-    AsyncPgConnection::establish(&database_url)
+    AsyncPgConnection::establish(&get_database_url())
         .unwrap_or_else(|_| panic!("Failed to establish DB connection"))
         .await
+}
+
+pub fn run_migrations() {
+    let mut conn = PgConnection::establish(&get_database_url())
+        .unwrap_or_else(|_| panic!("Failed to establish DB connection"));
+
+    println!("Running migrations...");
+    conn.run_pending_migrations(MIGRATIONS)
+        .unwrap_or_else(|_| panic!("Failed to run migrations"));
+    println!("Migrations complete");
+}
+
+fn get_database_url() -> String {
+    env::var("DATABASE_URL").expect("'DATABASE_URL' missing from environment")
 }

--- a/api/src/infrastructure/db_schema.rs
+++ b/api/src/infrastructure/db_schema.rs
@@ -27,4 +27,7 @@ diesel::table! {
 
 diesel::joinable!(job -> monitor (monitor_id));
 
-diesel::allow_tables_to_appear_in_same_query!(job, monitor);
+diesel::allow_tables_to_appear_in_same_query!(
+    job,
+    monitor,
+);

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::application::fairings::{cors::CORS, default_json::DefaultJSON};
 use crate::application::routes::{health, jobs, monitors};
-use crate::infrastructure::database::Db;
+use crate::infrastructure::database::{run_migrations, Db};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct DbConfig {
@@ -21,6 +21,8 @@ struct DbConfig {
 
 #[rocket::launch]
 pub fn rocket() -> Rocket<Build> {
+    run_migrations();
+
     let figment = Config::figment().merge((
         "databases.monitors",
         DbConfig {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -6,16 +6,29 @@ pub mod infrastructure;
 use std::env;
 
 use rocket::fs::FileServer;
-use rocket::{routes, Build, Rocket};
+use rocket::{routes, Build, Config, Rocket};
 use rocket_db_pools::Database;
+use serde::{Deserialize, Serialize};
 
 use crate::application::fairings::{cors::CORS, default_json::DefaultJSON};
 use crate::application::routes::{health, jobs, monitors};
 use crate::infrastructure::database::Db;
 
+#[derive(Debug, Deserialize, Serialize)]
+struct DbConfig {
+    url: String,
+}
+
 #[rocket::launch]
 pub fn rocket() -> Rocket<Build> {
-    rocket::build()
+    let figment = Config::figment().merge((
+        "databases.monitors",
+        DbConfig {
+            url: env::var("DATABASE_URL").expect("'DATABASE_URL' missing from environment"),
+        },
+    ));
+
+    rocket::custom(figment)
         .attach(Db::init())
         .attach(CORS)
         .attach(DefaultJSON)

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -48,8 +48,5 @@ pub fn rocket() -> Rocket<Build> {
                 jobs::finish_job,
             ],
         )
-        .mount(
-            "/api/v1/docs",
-            FileServer::from(env::var("DOCS_DIR").expect("Missing DOCS_DIR environment variable")),
-        )
+        .mount("/api/v1/docs", FileServer::from("./docs"))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
     build:
       dockerfile: ./Dockerfile
       context: .
+      target: builder
     stdin_open: true
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - cron-mon-network
 
   api-debug:
-    extends: rust-debug
+    extends: rust-cargo
     container_name: cron-mon-api-debug
     ports:
       - 8000:8000
@@ -38,7 +38,7 @@ services:
       - cron-mon-network
 
   monitor-debug:
-    extends: rust-debug
+    extends: rust-cargo
     container_name: cron-mon-monitor-debug
     depends_on:
       db:
@@ -49,7 +49,7 @@ services:
       - cron-mon-network
 
   integration-tests-rs:
-    extends: rust-debug
+    extends: rust-cargo
     container_name: rust-integration-tests
     depends_on:
       db:
@@ -106,8 +106,8 @@ services:
     volumes:
       - ./api:/usr/cron-mon/api
 
-  rust-debug:
-    image: cron-mon/rust-debug-image
+  rust-cargo:
+    image: cron-mon/rust-cargo-image
     build:
       dockerfile: ./Dockerfile
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,21 @@
-version: '3.7'
 services:
 
   api:
-    extends: base-rust
+    extends: rust-release
     container_name: cron-mon-api
+    ports:
+      - 8000:8000
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ./api
+    networks:
+      - default
+      - cron-mon-network
+
+  api-debug:
+    extends: rust-debug
+    container_name: cron-mon-api-debug
     ports:
       - 8000:8000
     depends_on:
@@ -15,8 +27,19 @@ services:
       - cron-mon-network
 
   monitor:
-    extends: base-rust
+    extends: rust-release
     container_name: cron-mon-monitor
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ./monitor
+    networks:
+      - default
+      - cron-mon-network
+
+  monitor-debug:
+    extends: rust-debug
+    container_name: cron-mon-monitor-debug
     depends_on:
       db:
         condition: service_healthy
@@ -26,7 +49,7 @@ services:
       - cron-mon-network
 
   integration-tests-rs:
-    extends: base-rust
+    extends: rust-debug
     container_name: rust-integration-tests
     depends_on:
       db:
@@ -71,8 +94,21 @@ services:
         condition: service_healthy
     command: psql -f /usr/share/seeds.sql
 
-  base-rust:
-    image: cron-mon/base-rust-image
+  rust-release:
+    image: cron-mon/rust-release-image
+    build:
+      dockerfile: ./Dockerfile
+      context: .
+    stdin_open: true
+    tty: true
+    environment:
+      DATABASE_URL: postgres://cron-mon-api:itsasecret@cron-mon-db/cron-mon
+      DOCS_DIR: /usr/cron-mon/api/docs
+    volumes:
+      - ./api:/usr/cron-mon/api
+
+  rust-debug:
+    image: cron-mon/rust-debug-image
     build:
       dockerfile: ./Dockerfile
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,11 +52,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
-    command: [
-      "postgres",
-      "-c",
-      "log_statement=all"
-    ]
+    command: [ "postgres", "-c", "log_statement=all" ]
 
   seeder:
     container_name: cron-mon-db-seeder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,6 @@ services:
     tty: true
     environment:
       DATABASE_URL: postgres://cron-mon-api:itsasecret@cron-mon-db/cron-mon
-      DOCS_DIR: /usr/cron-mon/api/docs
     volumes:
       - ./api:/usr/cron-mon/api
 
@@ -117,7 +116,6 @@ services:
     tty: true
     environment:
       DATABASE_URL: postgres://cron-mon-api:itsasecret@cron-mon-db/cron-mon
-      DOCS_DIR: /usr/cron-mon/api/docs
     volumes:
       - ./api:/usr/cron-mon/api
 


### PR DESCRIPTION
* Alters the Docker build process so that it's a multi-stage build, giving us an initial stage that has and uses Cargo, and a final stage that only has the bare minimum required to run a (release) build of Cron Mon.
* Simplifies the configuration so that only `DATABASE_URL` is required in the environment.
* Embeds the migrations within the application so that they are run during the setup of the API.
* Adds a second `Makefile` at `api/`, for use in the development container or the application container (`builder` stage), and adds a `make shell` command to the main, top-level `Makefile` to open a shell in the latter (the former can be done within your IDE).

Closes #20 
