### PR TITLE
chore: Bump Rust to v.1.80.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     defaults:
       run:
         working-directory: ./api
-    container: public.ecr.aws/docker/library/rust80.0-slim
+    container: public.ecr.aws/docker/library/rust:1.80.0-slim
     services:
       cron-mon-db:
         image: public.ecr.aws/docker/library/postgres:16.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust
-        run: rustup install 1.79.0
+        run: rustup install 1.80.0
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install rust
-        run: rustup install 1.79.0
+        run: rustup install 1.80.0
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
@@ -55,7 +55,7 @@ jobs:
     defaults:
       run:
         working-directory: ./api
-    container: public.ecr.aws/docker/library/rust:1.79.0-slim
+    container: public.ecr.aws/docker/library/rust80.0-slim
     services:
       cron-mon-db:
         image: public.ecr.aws/docker/library/postgres:16.1
@@ -101,7 +101,7 @@ jobs:
     defaults:
       run:
         working-directory: ./api
-    container: public.ecr.aws/docker/library/rust:1.79.0-slim
+    container: public.ecr.aws/docker/library/rust:1.80.0-slim
     services:
       cron-mon-db:
         image: public.ecr.aws/docker/library/postgres:16.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/rust:1.79.0-slim as builder
+FROM public.ecr.aws/docker/library/rust:1.80.0-slim as builder
 
 RUN apt-get update && apt-get install build-essential libpq-dev -y
 RUN rustup component add rustfmt clippy llvm-tools-preview


### PR DESCRIPTION
Rust v1.80.0 went stable on 2024-07-25 - lets use it! Hoping it makes `#[cfg(coverage(off))]` stable 🤞 