### PR TITLE
Feat/multi tenant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,5 @@
 .cargo
 api/target
 
-# PostgreSQL
-data
-
 # Miscellaneous
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ api/target
 
 # Miscellaneous
 .DS_Store
+lcov.info

--- a/api/src/application/routes/jobs.rs
+++ b/api/src/application/routes/jobs.rs
@@ -21,13 +21,13 @@ pub struct FinishJobInfo {
 #[rocket::get("/monitors/<monitor_id>/jobs/<job_id>")]
 pub async fn get_job(
     mut connection: Connection<Db>,
-    _jwt: Jwt,
+    jwt: Jwt,
     monitor_id: Uuid,
     job_id: Uuid,
 ) -> Result<Value, Error> {
     let mut service = get_fetch_job_service(&mut connection);
 
-    let job = service.fetch_by_id(monitor_id, job_id).await?;
+    let job = service.fetch_by_id(monitor_id, &jwt.tenant, job_id).await?;
 
     Ok(json!({"data": job}))
 }

--- a/api/src/application/services/fetch_job.rs
+++ b/api/src/application/services/fetch_job.rs
@@ -14,8 +14,13 @@ impl<T: Repository<Monitor>> FetchJobService<T> {
         Self { repo }
     }
 
-    pub async fn fetch_by_id(&mut self, monitor_id: Uuid, job_id: Uuid) -> Result<Job, Error> {
-        let monitor_opt = self.repo.get(monitor_id).await?;
+    pub async fn fetch_by_id(
+        &mut self,
+        monitor_id: Uuid,
+        tenant: &str,
+        job_id: Uuid,
+    ) -> Result<Job, Error> {
+        let monitor_opt = self.repo.get(monitor_id, tenant).await?;
 
         match monitor_opt {
             Some(mut monitor) => {
@@ -47,10 +52,11 @@ mod tests {
         let mut mock = MockRepository::new();
         mock.expect_get()
             .once()
-            .with(eq(monitor_id))
-            .returning(|_| {
+            .with(eq(monitor_id), eq("tenant"))
+            .returning(|_, _| {
                 Ok(Some(Monitor {
                     monitor_id: gen_uuid("71d1c46c-ef86-4fcb-b8b4-b2fee56a4d2f"),
+                    tenant: "tenant".to_owned(),
                     name: "foo".to_owned(),
                     expected_duration: 300,
                     grace_duration: 100,
@@ -69,7 +75,11 @@ mod tests {
         let mut service = FetchJobService::new(mock);
 
         let job_result = service
-            .fetch_by_id(monitor_id, gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"))
+            .fetch_by_id(
+                monitor_id,
+                "tenant",
+                gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
+            )
             .await;
 
         assert_eq!(
@@ -92,13 +102,17 @@ mod tests {
         let mut mock = MockRepository::new();
         mock.expect_get()
             .once()
-            .with(eq(monitor_id))
-            .returning(|_| Ok(None));
+            .with(eq(monitor_id), eq("tenant"))
+            .returning(|_, _| Ok(None));
 
         let mut service = FetchJobService::new(mock);
 
         let job_result = service
-            .fetch_by_id(monitor_id, gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"))
+            .fetch_by_id(
+                monitor_id,
+                "tenant",
+                gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
+            )
             .await;
 
         assert_eq!(job_result, Err(Error::MonitorNotFound(monitor_id)));
@@ -110,10 +124,11 @@ mod tests {
         let mut mock = MockRepository::new();
         mock.expect_get()
             .once()
-            .with(eq(monitor_id))
-            .returning(|_| {
+            .with(eq(monitor_id), eq("tenant"))
+            .returning(|_, _| {
                 Ok(Some(Monitor {
                     monitor_id: gen_uuid("71d1c46c-ef86-4fcb-b8b4-b2fee56a4d2f"),
+                    tenant: "tenant".to_owned(),
                     name: "foo".to_owned(),
                     expected_duration: 300,
                     grace_duration: 100,
@@ -124,7 +139,11 @@ mod tests {
         let mut service = FetchJobService::new(mock);
 
         let job_result = service
-            .fetch_by_id(monitor_id, gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"))
+            .fetch_by_id(
+                monitor_id,
+                "tenant",
+                gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
+            )
             .await;
 
         assert_eq!(

--- a/api/src/application/services/finish_job.rs
+++ b/api/src/application/services/finish_job.rs
@@ -18,11 +18,12 @@ impl<T: Repository<Monitor>> FinishJobService<T> {
     pub async fn finish_job_for_monitor(
         &mut self,
         monitor_id: Uuid,
+        tenant: &str,
         job_id: Uuid,
         succeeded: bool,
         output: &Option<String>,
     ) -> Result<Job, Error> {
-        let monitor_opt = self.repo.get(monitor_id).await?;
+        let monitor_opt = self.repo.get(monitor_id, tenant).await?;
 
         match monitor_opt {
             Some(mut monitor) => match monitor.finish_job(job_id, succeeded, output.clone()) {
@@ -70,10 +71,14 @@ mod tests {
         let mut mock = MockRepository::new();
         mock.expect_get()
             .once()
-            .with(eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")))
-            .returning(|_| {
+            .with(
+                eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")),
+                eq("tenant"),
+            )
+            .returning(|_, _| {
                 Ok(Some(Monitor {
                     monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+                    tenant: "tenant".to_owned(),
                     name: "foo".to_owned(),
                     expected_duration: 300,
                     grace_duration: 100,
@@ -93,6 +98,7 @@ mod tests {
             .once()
             .withf(|monitor: &Monitor| {
                 monitor.monitor_id == gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")
+                    && monitor.tenant == "tenant"
                     && !monitor.jobs[0].in_progress()
                     && monitor.jobs[0].duration() == Some(320)
             })
@@ -102,6 +108,7 @@ mod tests {
         let job = service
             .finish_job_for_monitor(
                 gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+                "tenant",
                 gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
                 true,
                 &Some("Job complete".to_owned()),
@@ -131,13 +138,17 @@ mod tests {
         let mut mock = MockRepository::new();
         mock.expect_get()
             .once()
-            .with(eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")))
-            .returning(|_| Ok(None));
+            .with(
+                eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")),
+                eq("tenant"),
+            )
+            .returning(|_, _| Ok(None));
 
         let mut service = FinishJobService::new(mock);
         let result = service
             .finish_job_for_monitor(
                 gen_uuid("41ebffb4-A188-48E9-8ec1-61380085cde3"),
+                "tenant",
                 gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
                 true,
                 &Some("Job complete".to_owned()),
@@ -163,10 +174,14 @@ mod tests {
         let mut mock = MockRepository::new();
         mock.expect_get()
             .once()
-            .with(eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")))
-            .returning(|_| {
+            .with(
+                eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")),
+                eq("tenant"),
+            )
+            .returning(|_, _| {
                 Ok(Some(Monitor {
                     monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+                    tenant: "tenant".to_owned(),
                     name: "foo".to_owned(),
                     expected_duration: 300,
                     grace_duration: 100,
@@ -178,6 +193,7 @@ mod tests {
         let result = service
             .finish_job_for_monitor(
                 gen_uuid("41ebffb4-A188-48E9-8ec1-61380085cde3"),
+                "tenant",
                 gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
                 true,
                 &Some("Job complete".to_owned()),
@@ -213,10 +229,14 @@ mod tests {
         let mut mock = MockRepository::new();
         mock.expect_get()
             .once()
-            .with(eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")))
-            .returning(|_| {
+            .with(
+                eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")),
+                eq("tenant"),
+            )
+            .returning(|_, _| {
                 Ok(Some(Monitor {
                     monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+                    tenant: "tenant".to_owned(),
                     name: "foo".to_owned(),
                     expected_duration: 300,
                     grace_duration: 100,
@@ -236,6 +256,7 @@ mod tests {
         let job = service
             .finish_job_for_monitor(
                 gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+                "tenant",
                 gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
                 true,
                 &Some("Job complete".to_owned()),

--- a/api/src/application/services/process_late_jobs.rs
+++ b/api/src/application/services/process_late_jobs.rs
@@ -50,6 +50,7 @@ mod tests {
             Ok(vec![
                 Monitor {
                     monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+                    tenant: "foo-tenant".to_owned(),
                     name: "background-task.sh".to_owned(),
                     expected_duration: 300,
                     grace_duration: 100,
@@ -85,6 +86,7 @@ mod tests {
                 },
                 Monitor {
                     monitor_id: gen_uuid("841bdefb-e45c-4361-a8cb-8d247f4a088b"),
+                    tenant: "bar-tenant".to_owned(),
                     name: "get-pending-orders | generate invoices".to_owned(),
                     expected_duration: 21_600,
                     grace_duration: 1_800,

--- a/api/src/application/services/start_job.rs
+++ b/api/src/application/services/start_job.rs
@@ -15,8 +15,12 @@ impl<T: Repository<Monitor>> StartJobService<T> {
         Self { repo }
     }
 
-    pub async fn start_job_for_monitor(&mut self, monitor_id: Uuid) -> Result<Job, Error> {
-        let mut monitor_opt = self.repo.get(monitor_id).await?;
+    pub async fn start_job_for_monitor(
+        &mut self,
+        monitor_id: Uuid,
+        tenant: &str,
+    ) -> Result<Job, Error> {
+        let mut monitor_opt = self.repo.get(monitor_id, tenant).await?;
 
         match &mut monitor_opt {
             Some(monitor) => {
@@ -54,10 +58,14 @@ mod tests {
         let mut mock = MockRepository::new();
         mock.expect_get()
             .once()
-            .with(eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")))
-            .returning(|_| {
+            .with(
+                eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")),
+                eq("tenant"),
+            )
+            .returning(|_, _| {
                 Ok(Some(Monitor {
                     monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+                    tenant: "tenant".to_owned(),
                     name: "foo".to_owned(),
                     expected_duration: 300,
                     grace_duration: 100,
@@ -68,6 +76,7 @@ mod tests {
             .once()
             .withf(|monitor: &Monitor| {
                 monitor.monitor_id == gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")
+                    && monitor.tenant == "tenant"
                     && monitor.jobs.len() == 1
                     && monitor.jobs[0].in_progress()
             })
@@ -75,7 +84,7 @@ mod tests {
 
         let mut service = StartJobService::new(mock);
         let job = service
-            .start_job_for_monitor(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"))
+            .start_job_for_monitor(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"), "tenant")
             .await
             .unwrap();
 
@@ -104,13 +113,18 @@ mod tests {
         let mut mock = MockRepository::new();
         mock.expect_get()
             .once()
-            .with(eq(gen_uuid("01a92c6c-6803-409d-b675-022fff62575a")))
-            .returning(|_| Ok(None));
+            .with(
+                eq(gen_uuid("01a92c6c-6803-409d-b675-022fff62575a")),
+                eq("tenant"),
+            )
+            .returning(|_, _| Ok(None));
 
         let mut service = StartJobService::new(mock);
 
         let non_existent_id = gen_uuid("01a92c6c-6803-409d-b675-022fff62575a");
-        let start_result = service.start_job_for_monitor(non_existent_id).await;
+        let start_result = service
+            .start_job_for_monitor(non_existent_id, "tenant")
+            .await;
         assert_eq!(start_result, Err(Error::MonitorNotFound(non_existent_id)));
 
         logs_assert(|logs| {

--- a/api/src/domain/services/monitors.rs
+++ b/api/src/domain/services/monitors.rs
@@ -44,6 +44,7 @@ mod tests {
         vec![
             Monitor {
                 monitor_id: gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"),
+                tenant: "foo-tenant".to_owned(),
                 name: "db-backup.py".to_owned(),
                 expected_duration: 1800,
                 grace_duration: 600,
@@ -51,6 +52,7 @@ mod tests {
             },
             Monitor {
                 monitor_id: gen_uuid("cc6cf74e-b25d-4c8c-94a6-914e3f139c14"),
+                tenant: "bar-tenant".to_owned(),
                 name: "generate-orders.sh".to_owned(),
                 expected_duration: 3600,
                 grace_duration: 1200,
@@ -77,6 +79,7 @@ mod tests {
             },
             Monitor {
                 monitor_id: gen_uuid("d1f3b3b4-0b3b-4b3b-8b3b-3b3b3b3b3b3b"),
+                tenant: "foo-tenant".to_owned(),
                 name: "send-emails.sh".to_owned(),
                 expected_duration: 7200,
                 grace_duration: 1800,

--- a/api/src/infrastructure/db_schema.rs
+++ b/api/src/infrastructure/db_schema.rs
@@ -22,6 +22,7 @@ diesel::table! {
         name -> Varchar,
         expected_duration -> Int4,
         grace_duration -> Int4,
+        tenant -> Varchar,
     }
 }
 

--- a/api/src/infrastructure/migrations/2024-10-04-192304_add_tenant_to_monitor/down.sql
+++ b/api/src/infrastructure/migrations/2024-10-04-192304_add_tenant_to_monitor/down.sql
@@ -1,0 +1,8 @@
+-- Drop the indexes and constraints on the tenant column.
+DROP INDEX idx_monitor_tenant;
+DROP INDEX idx_monitor_monitor_id_tenant;
+ALTER TABLE monitor
+    DROP CONSTRAINT key_monitor_monitor_id_tenant;
+
+-- Drop the tenant column.
+ALTER TABLE monitor DROP tenant;

--- a/api/src/infrastructure/migrations/2024-10-04-192304_add_tenant_to_monitor/up.sql
+++ b/api/src/infrastructure/migrations/2024-10-04-192304_add_tenant_to_monitor/up.sql
@@ -1,0 +1,18 @@
+ALTER TABLE monitor
+	ADD tenant VARCHAR NULL;
+
+UPDATE
+	monitor
+SET
+	tenant = 'cron-mon-io/cron-mon';
+
+ALTER TABLE monitor
+    ALTER COLUMN tenant SET NOT NULL;
+
+-- The combination of monitor_id and tenant should be unique.
+ALTER TABLE monitor
+    ADD CONSTRAINT key_monitor_monitor_id_tenant UNIQUE (monitor_id, tenant);
+
+-- Add indexes on the tenant column and the combination of monitor_id and tenant columns.
+CREATE INDEX idx_monitor_tenant ON monitor(tenant);
+CREATE INDEX idx_monitor_monitor_id_tenant ON monitor(monitor_id, tenant);

--- a/api/src/infrastructure/models/monitor.rs
+++ b/api/src/infrastructure/models/monitor.rs
@@ -12,6 +12,7 @@ use crate::infrastructure::models::job::JobData;
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct MonitorData {
     pub monitor_id: Uuid,
+    pub tenant: String,
     pub name: String,
     pub expected_duration: i32,
     pub grace_duration: i32,
@@ -21,6 +22,7 @@ impl MonitorData {
     pub fn to_model(&self, job_datas: &[JobData]) -> Result<Monitor, Error> {
         Ok(Monitor {
             monitor_id: self.monitor_id,
+            tenant: self.tenant.clone(),
             name: self.name.clone(),
             expected_duration: self.expected_duration,
             grace_duration: self.grace_duration,
@@ -37,6 +39,7 @@ impl From<&Monitor> for (MonitorData, Vec<JobData>) {
         (
             MonitorData {
                 monitor_id: value.monitor_id,
+                tenant: value.tenant.clone(),
                 name: value.name.clone(),
                 expected_duration: value.expected_duration,
                 grace_duration: value.grace_duration,
@@ -72,6 +75,7 @@ mod tests {
     fn test_monitor_to_db_data() {
         let monitor = Monitor {
             monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+            tenant: "foo-tenant".to_owned(),
             name: "foo".to_owned(),
             expected_duration: 300,
             grace_duration: 100,
@@ -89,6 +93,7 @@ mod tests {
         let (monitor_data, job_data) = <(MonitorData, Vec<JobData>)>::from(&monitor);
 
         assert_eq!(monitor_data.monitor_id, monitor.monitor_id);
+        assert_eq!(monitor_data.tenant, monitor.tenant);
         assert_eq!(monitor_data.name, monitor.name);
         assert_eq!(monitor_data.expected_duration, monitor.expected_duration);
         assert_eq!(monitor_data.grace_duration, monitor.grace_duration);
@@ -114,6 +119,7 @@ mod tests {
     fn test_converting_db_to_monitor() {
         let monitor_data = MonitorData {
             monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+            tenant: "foo-tenant".to_owned(),
             name: "foo".to_owned(),
             expected_duration: 300,
             grace_duration: 100,
@@ -135,6 +141,7 @@ mod tests {
             monitor.monitor_id,
             gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")
         );
+        assert_eq!(monitor.tenant, "foo-tenant".to_owned());
         assert_eq!(monitor.name, "foo".to_owned());
         assert_eq!(monitor.expected_duration, 300);
         assert_eq!(monitor.grace_duration, 100);

--- a/api/src/infrastructure/repositories/mod.rs
+++ b/api/src/infrastructure/repositories/mod.rs
@@ -14,9 +14,9 @@ use crate::errors::Error;
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait Repository<T: Send + Sync> {
-    async fn get(&mut self, entity_id: Uuid) -> Result<Option<T>, Error>;
+    async fn get(&mut self, entity_id: Uuid, tenant: &str) -> Result<Option<T>, Error>;
 
-    async fn all(&mut self) -> Result<Vec<T>, Error>;
+    async fn all(&mut self, tenant: &str) -> Result<Vec<T>, Error>;
 
     async fn save(&mut self, entity: &T) -> Result<(), Error>;
 

--- a/api/src/infrastructure/seeding/seeds.sql
+++ b/api/src/infrastructure/seeding/seeds.sql
@@ -4,13 +4,13 @@ DELETE FROM monitor;
 
 -- Monitors.
 INSERT INTO monitor
-    (monitor_id, "name", expected_duration, grace_duration)
+    (monitor_id, tenant, "name", expected_duration, grace_duration)
 VALUES
-    ('c1bf0515-df39-448b-aa95-686360a33b36', 'db-backup.py',                  1800,  600),
-    ('f0b291fe-bd41-4787-bc2d-1329903f7a6a', 'generate-orders.sh',            5400,  720),
-    ('a04376e2-0fb5-4949-9744-7c5d0a50b411', 'init-philanges',                900,   300),
-    ('309a68f1-d6a2-4312-8012-49c1b9b9af25', 'gen-manifests | send-manifest', 300,   120),
-    ('0798c530-34a4-4452-b2dc-f8140fd498d5', 'bill-and-invoice',              10800, 1800);
+    ('c1bf0515-df39-448b-aa95-686360a33b36', 'cron-mon', 'db-backup.py',                  1800,  600),
+    ('f0b291fe-bd41-4787-bc2d-1329903f7a6a', 'cron-mon', 'generate-orders.sh',            5400,  720),
+    ('a04376e2-0fb5-4949-9744-7c5d0a50b411', 'cron-mon', 'init-philanges',                900,   300),
+    ('309a68f1-d6a2-4312-8012-49c1b9b9af25', 'cron-mon', 'gen-manifests | send-manifest', 300,   120),
+    ('0798c530-34a4-4452-b2dc-f8140fd498d5', 'cron-mon', 'bill-and-invoice',              10800, 1800);
 
 -- Jobs.
 INSERT INTO job

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -39,18 +39,21 @@ pub fn seed_data() -> (Vec<MonitorData>, Vec<JobData>) {
         vec![
             MonitorData {
                 monitor_id: gen_uuid("a04376e2-0fb5-4949-9744-7c5d0a50b411"),
+                tenant: "foo".to_owned(),
                 name: "init-philanges".to_string(),
                 expected_duration: 900,
                 grace_duration: 300,
             },
             MonitorData {
                 monitor_id: gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"),
+                tenant: "foo".to_owned(),
                 name: "db-backup.py".to_string(),
                 expected_duration: 1800,
                 grace_duration: 600,
             },
             MonitorData {
                 monitor_id: gen_uuid("f0b291fe-bd41-4787-bc2d-1329903f7a6a"),
+                tenant: "foo".to_owned(),
                 name: "generate-orders.sh".to_string(),
                 expected_duration: 5400,
                 grace_duration: 720,

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -58,6 +58,13 @@ pub fn seed_data() -> (Vec<MonitorData>, Vec<JobData>) {
                 expected_duration: 5400,
                 grace_duration: 720,
             },
+            MonitorData {
+                monitor_id: gen_uuid("cc6cf74e-b25d-4c8c-94a6-914e3f139c14"),
+                tenant: "bar".to_owned(),
+                name: "data-snapshot.py".to_string(),
+                expected_duration: 3600,
+                grace_duration: 1200,
+            },
         ],
         vec![
             JobData {

--- a/api/tests/monitor_routes_test.rs
+++ b/api/tests/monitor_routes_test.rs
@@ -76,6 +76,31 @@ async fn test_get_monitor_when_monitor_does_not_exist() {
 }
 
 #[tokio::test]
+async fn test_get_monitor_with_wrong_tenant() {
+    let (_mock_server, client) = get_test_client("test-kid", true).await;
+
+    let response = client
+        .get("/api/v1/monitors/c1bf0515-df39-448b-aa95-686360a33b36")
+        .header(create_auth_header("test-kid", "test-user", "bar"))
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::NotFound);
+    assert_eq!(
+        response.into_json::<Value>().await.unwrap(),
+        json!({
+            "error": {
+                "code": 404,
+                "reason": "Monitor Not Found",
+                "description": (
+                    "Failed to find monitor with id 'c1bf0515-df39-448b-aa95-686360a33b36'"
+                )
+            }
+        }),
+    )
+}
+
+#[tokio::test]
 async fn test_list_monitors() {
     let (_mock_server, client) = get_test_client("test-kid", true).await;
 


### PR DESCRIPTION
Add support for multi-tenancy.

> [!NOTE]
> Note this includes a temporary hack to get around needing a tenant when fetching monitors, meaning starting and stopping jobs now requires a `tenant` to be passed in the JSON payload. Once we have API keys in place for these endpoints we'll get the tenant from the API key. This does the job for now though.

Relates to #22 