### PR TITLE
Feat/api keys

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -9,3 +9,6 @@ echo "source /etc/bash_completion" >> ~/.bashrc
 # Setup starship prompt
 curl -sS https://starship.rs/install.sh | sh -s -- -y
 echo 'eval "$(starship init bash)"' >> ~/.bashrc
+
+# Set VS Code as default editor
+echo 'export EDITOR="code "' >> ~/.bashrc

--- a/api/docs/adr/0002-database-managed-by-user.md
+++ b/api/docs/adr/0002-database-managed-by-user.md
@@ -1,4 +1,4 @@
-# 3. Database will be managed by the user
+# 2. Database will be managed by the user
 
 Date: 2024-04-10
 

--- a/api/docs/adr/0003-api-will-be-authenticated.md
+++ b/api/docs/adr/0003-api-will-be-authenticated.md
@@ -1,4 +1,4 @@
-# 2. The API will be authenticated
+# 3. The API will be authenticated
 
 Date: 2024-08-06
 

--- a/api/docs/adr/0005-api-key-usage-recorded.md
+++ b/api/docs/adr/0005-api-key-usage-recorded.md
@@ -1,0 +1,33 @@
+# 5. API key usage will be recorded
+
+Date: 2024-10-13
+
+## Status
+
+Accepted
+
+
+
+## Context
+
+Starting and finishing jobs cannot be authenticated with CronMon's JWT authentication, since these
+JWT's could be short lived (this is ultimately up to the user and how they've setup their Keycloak
+server), so instead we use API keys to authenticate these requests. Since an API key is valid
+indefinitely (unless the end-user deletes it), this means this form of authentication is a lot less secure than JWTs.
+
+## Decision
+
+Everytime an API key is used to access a monitor to either start or finish a Job, it's usage will
+be recorded, including the time at which it was used, and the monitor it was used for. This
+information can then be retrievable via the API, allowing end-users to see when their API keys are
+used. This means that should an end-user suspect that one of their API keys has become comprimised,
+they could use this information to see if it's being as expected.
+
+## Consequences
+
+Because we'll need access to the API key not just when authenticating the request, but also once
+we've retrieved the Monitor, so that we can record the usage of the API key against that monitor, we
+won't be able to create a simple
+[Request guard](https://rocket.rs/guide/v0.5/requests/#request-guards) here to take care of all
+aspects of API key auth. Instead, we'll also need to bring in some of this into the actual
+CronMon domain.

--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -271,6 +271,8 @@ paths:
       tags:
         - Jobs
       summary: "Start a Job within a Monitor"
+      security:
+        - apiKeyAuth: []
       parameters:
         - in: path
           name: monitor_id
@@ -363,6 +365,8 @@ paths:
       tags:
         - Jobs
       summary: "Finish a Job within a Monitor"
+      security:
+        - apiKeyAuth: []
       parameters:
         - in: path
           name: monitor_id
@@ -701,3 +705,7 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key

--- a/api/src/application/routes/jobs.rs
+++ b/api/src/application/routes/jobs.rs
@@ -17,7 +17,6 @@ use crate::infrastructure::middleware::guards::api_key::ApiKey;
 pub struct FinishJobInfo {
     succeeded: bool,
     output: Option<String>,
-    tenant: String, // TODO: Remove this once we have API keys.
 }
 
 #[rocket::get("/monitors/<monitor_id>/jobs/<job_id>")]
@@ -52,6 +51,7 @@ pub async fn start_job<'r>(
 )]
 pub async fn finish_job(
     pool: &State<DbPool>,
+    key: ApiKey,
     monitor_id: Uuid,
     job_id: Uuid,
     finish_job_info: Json<FinishJobInfo>,
@@ -61,7 +61,7 @@ pub async fn finish_job(
     let job = service
         .finish_job_for_monitor(
             monitor_id,
-            &finish_job_info.tenant,
+            &key.0,
             job_id,
             finish_job_info.succeeded,
             &finish_job_info.output,

--- a/api/src/application/services/finish_job.rs
+++ b/api/src/application/services/finish_job.rs
@@ -6,13 +6,13 @@ use crate::domain::models::monitor::Monitor;
 use crate::errors::Error;
 use crate::infrastructure::repositories::Repository;
 
-pub struct FinishJobService<T: Repository<Monitor>> {
-    repo: T,
+pub struct FinishJobService<MonitorRepo: Repository<Monitor>> {
+    monitor_repo: MonitorRepo,
 }
 
-impl<T: Repository<Monitor>> FinishJobService<T> {
-    pub fn new(repo: T) -> Self {
-        Self { repo }
+impl<MonitorRepo: Repository<Monitor>> FinishJobService<MonitorRepo> {
+    pub fn new(monitor_repo: MonitorRepo) -> Self {
+        Self { monitor_repo }
     }
 
     pub async fn finish_job_for_monitor(
@@ -23,7 +23,7 @@ impl<T: Repository<Monitor>> FinishJobService<T> {
         succeeded: bool,
         output: &Option<String>,
     ) -> Result<Job, Error> {
-        let monitor_opt = self.repo.get(monitor_id, tenant).await?;
+        let monitor_opt = self.monitor_repo.get(monitor_id, tenant).await?;
 
         match monitor_opt {
             Some(mut monitor) => match monitor.finish_job(job_id, succeeded, output.clone()) {
@@ -32,7 +32,7 @@ impl<T: Repository<Monitor>> FinishJobService<T> {
                     // as mutable above, meaning we can't borrow it immutably when saving it.
                     let job = job.clone();
 
-                    self.repo.save(&monitor).await?;
+                    self.monitor_repo.save(&monitor).await?;
 
                     info!(
                         monitor_id = monitor_id.to_string(),

--- a/api/src/application/services/finish_job.rs
+++ b/api/src/application/services/finish_job.rs
@@ -1,54 +1,103 @@
 use tracing::{error, info};
 use uuid::Uuid;
 
+use crate::domain::models::api_key::ApiKey;
 use crate::domain::models::job::Job;
 use crate::domain::models::monitor::Monitor;
 use crate::errors::Error;
+use crate::infrastructure::repositories::api_keys::GetByKey;
 use crate::infrastructure::repositories::Repository;
 
-pub struct FinishJobService<MonitorRepo: Repository<Monitor>> {
+pub struct FinishJobService<
+    MonitorRepo: Repository<Monitor>,
+    ApiKeyRepo: Repository<ApiKey> + GetByKey,
+> {
     monitor_repo: MonitorRepo,
+    api_key_repo: ApiKeyRepo,
 }
 
-impl<MonitorRepo: Repository<Monitor>> FinishJobService<MonitorRepo> {
-    pub fn new(monitor_repo: MonitorRepo) -> Self {
-        Self { monitor_repo }
+impl<MonitorRepo: Repository<Monitor>, ApiKeyRepo: Repository<ApiKey> + GetByKey>
+    FinishJobService<MonitorRepo, ApiKeyRepo>
+{
+    pub fn new(monitor_repo: MonitorRepo, api_key_repo: ApiKeyRepo) -> Self {
+        Self {
+            monitor_repo,
+            api_key_repo,
+        }
     }
 
     pub async fn finish_job_for_monitor(
         &mut self,
         monitor_id: Uuid,
-        tenant: &str,
+        api_key: &str,
         job_id: Uuid,
         succeeded: bool,
         output: &Option<String>,
     ) -> Result<Job, Error> {
-        let monitor_opt = self.monitor_repo.get(monitor_id, tenant).await?;
+        let mut key = self.validate_key(api_key).await?;
+
+        let monitor_opt = self.monitor_repo.get(monitor_id, &key.tenant).await?;
 
         match monitor_opt {
-            Some(mut monitor) => match monitor.finish_job(job_id, succeeded, output.clone()) {
-                Ok(job) => {
-                    // Need to clone the Job here, since it's part of the Monitor which is declared
-                    // as mutable above, meaning we can't borrow it immutably when saving it.
-                    let job = job.clone();
+            Some(mut monitor) => {
+                // Evertime an API key is used to access a monitor, we record it's usage. This is
+                // useful for monitoring and auditing purposes, since API keys aren't as secure as
+                // JWTs.
+                self.record_monitor_usage(&mut key, &monitor).await?;
 
-                    self.monitor_repo.save(&monitor).await?;
+                let finished_job = self
+                    .finish_job(&mut monitor, job_id, succeeded, output)
+                    .await?;
 
-                    info!(
-                        monitor_id = monitor_id.to_string(),
-                        "Finished Job('{}')", job_id
-                    );
-                    Ok(job)
-                }
-                Err(e) => {
-                    error!(
-                        monitor_id = monitor_id.to_string(),
-                        "Error finishing Job('{}'): {:?}", job_id, e
-                    );
-                    Err(e)
-                }
-            },
+                info!(
+                    monitor_id = monitor_id.to_string(),
+                    "Finished Job('{}')", job_id
+                );
+                Ok(finished_job)
+            }
             None => Err(Error::MonitorNotFound(monitor_id)),
+        }
+    }
+
+    async fn validate_key(&mut self, key: &str) -> Result<ApiKey, Error> {
+        let api_key = self.api_key_repo.get_by_key(key).await?;
+        match api_key {
+            Some(key) => Ok(key),
+            None => Err(Error::Unauthorized("Invalid API key".to_owned())),
+        }
+    }
+
+    async fn record_monitor_usage(
+        &mut self,
+        key: &mut ApiKey,
+        monitor: &Monitor,
+    ) -> Result<(), Error> {
+        key.record_usage(monitor)?;
+        self.api_key_repo.save(key).await
+    }
+
+    async fn finish_job(
+        &mut self,
+        monitor: &mut Monitor,
+        job_id: Uuid,
+        succeeded: bool,
+        output: &Option<String>,
+    ) -> Result<Job, Error> {
+        match monitor.finish_job(job_id, succeeded, output.clone()) {
+            Ok(job) => {
+                // Need to clone the Job here, since it's part of the Monitor which is declared as
+                // mutable above, meaning we can't borrow it immutably when saving it.
+                let job = job.clone();
+                self.monitor_repo.save(monitor).await?;
+                Ok(job)
+            }
+            Err(err) => {
+                error!(
+                    monitor_id = monitor.monitor_id.to_string(),
+                    "Error finishing Job('{}'): {:?}", job_id, err
+                );
+                Err(err)
+            }
         }
     }
 }
@@ -61,6 +110,8 @@ mod tests {
     use test_utils::logging::TracingLog;
     use test_utils::{gen_relative_datetime, gen_uuid};
 
+    use crate::domain::models::api_key::ApiKey;
+    use crate::infrastructure::repositories::mock_api_key_repo::MockApiKeyRepo;
     use crate::infrastructure::repositories::MockRepository;
 
     use super::{Error, FinishJobService, Job, Monitor};
@@ -68,8 +119,9 @@ mod tests {
     #[traced_test]
     #[tokio::test(start_paused = true)]
     async fn test_finish_job_service() {
-        let mut mock = MockRepository::new();
-        mock.expect_get()
+        let mut mock_monitor_repo = MockRepository::new();
+        mock_monitor_repo
+            .expect_get()
             .once()
             .with(
                 eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")),
@@ -93,8 +145,8 @@ mod tests {
                     .unwrap()],
                 }))
             });
-
-        mock.expect_save()
+        mock_monitor_repo
+            .expect_save()
             .once()
             .withf(|monitor: &Monitor| {
                 monitor.monitor_id == gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")
@@ -104,11 +156,11 @@ mod tests {
             })
             .returning(|_| Ok(()));
 
-        let mut service = FinishJobService::new(mock);
+        let mut service = FinishJobService::new(mock_monitor_repo, setup_mock_api_key_repo());
         let job = service
             .finish_job_for_monitor(
                 gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
-                "tenant",
+                "foo-key",
                 gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
                 true,
                 &Some("Job complete".to_owned()),
@@ -135,20 +187,30 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn test_monitor_not_found() {
-        let mut mock = MockRepository::new();
-        mock.expect_get()
+        let mut mock_api_key_repo = MockApiKeyRepo::new();
+        mock_api_key_repo
+            .expect_get_by_key()
+            .once()
+            .with(eq("foo-key"))
+            .returning(|_| Ok(Some(ApiKey::new("foo-key".to_owned(), "tenant".to_owned()))));
+        mock_api_key_repo.expect_save().never();
+
+        let mut mock_monitor_repo = MockRepository::new();
+        mock_monitor_repo
+            .expect_get()
             .once()
             .with(
                 eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")),
                 eq("tenant"),
             )
             .returning(|_, _| Ok(None));
+        mock_monitor_repo.expect_save().never();
 
-        let mut service = FinishJobService::new(mock);
+        let mut service = FinishJobService::new(mock_monitor_repo, mock_api_key_repo);
         let result = service
             .finish_job_for_monitor(
                 gen_uuid("41ebffb4-A188-48E9-8ec1-61380085cde3"),
-                "tenant",
+                "foo-key",
                 gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
                 true,
                 &Some("Job complete".to_owned()),
@@ -171,8 +233,9 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn test_job_not_found() {
-        let mut mock = MockRepository::new();
-        mock.expect_get()
+        let mut mock_monitor_repo = MockRepository::new();
+        mock_monitor_repo
+            .expect_get()
             .once()
             .with(
                 eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")),
@@ -188,12 +251,13 @@ mod tests {
                     jobs: vec![],
                 }))
             });
+        mock_monitor_repo.expect_save().never();
 
-        let mut service = FinishJobService::new(mock);
+        let mut service = FinishJobService::new(mock_monitor_repo, setup_mock_api_key_repo());
         let result = service
             .finish_job_for_monitor(
                 gen_uuid("41ebffb4-A188-48E9-8ec1-61380085cde3"),
-                "tenant",
+                "foo-key",
                 gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
                 true,
                 &Some("Job complete".to_owned()),
@@ -226,8 +290,9 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn test_job_already_finished() {
-        let mut mock = MockRepository::new();
-        mock.expect_get()
+        let mut mock_monitor_repo = MockRepository::new();
+        mock_monitor_repo
+            .expect_get()
             .once()
             .with(
                 eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")),
@@ -251,12 +316,13 @@ mod tests {
                     .unwrap()],
                 }))
             });
+        mock_monitor_repo.expect_save().never();
 
-        let mut service = FinishJobService::new(mock);
+        let mut service = FinishJobService::new(mock_monitor_repo, setup_mock_api_key_repo());
         let job = service
             .finish_job_for_monitor(
                 gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
-                "tenant",
+                "foo-key",
                 gen_uuid("01a92c6c-6803-409d-b675-022fff62575a"),
                 true,
                 &Some("Job complete".to_owned()),
@@ -282,5 +348,27 @@ mod tests {
             );
             Ok(())
         });
+    }
+
+    fn setup_mock_api_key_repo() -> MockApiKeyRepo {
+        let mut mock_api_key_repo = MockApiKeyRepo::new();
+        mock_api_key_repo
+            .expect_get_by_key()
+            .once()
+            .with(eq("foo-key"))
+            .returning(|_| Ok(Some(ApiKey::new("foo-key".to_owned(), "tenant".to_owned()))));
+        mock_api_key_repo
+            .expect_save()
+            .once()
+            .withf(|key: &ApiKey| {
+                // We're checking that the key was updated with the last used information.
+                key.last_used.is_some()
+                    && key.last_used_monitor_id
+                        == Some(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"))
+                    && key.last_used_monitor_name == Some("foo".to_owned())
+            })
+            .returning(|_| Ok(()));
+
+        mock_api_key_repo
     }
 }

--- a/api/src/application/services/mod.rs
+++ b/api/src/application/services/mod.rs
@@ -44,8 +44,10 @@ pub fn get_fetch_monitors_service<'a>(
     )
 }
 
-pub fn get_finish_job_service(pool: &DbPool) -> FinishJobService<MonitorRepository> {
-    FinishJobService::new(MonitorRepository::new(pool))
+pub fn get_finish_job_service(
+    pool: &DbPool,
+) -> FinishJobService<MonitorRepository, ApiKeyRepository> {
+    FinishJobService::new(MonitorRepository::new(pool), ApiKeyRepository::new(pool))
 }
 
 pub fn get_process_late_jobs_service(

--- a/api/src/application/services/mod.rs
+++ b/api/src/application/services/mod.rs
@@ -11,6 +11,7 @@ use crate::domain::models::monitor::Monitor;
 use crate::domain::services::monitors::order_monitors_by_last_started_job;
 use crate::infrastructure::database::DbPool;
 use crate::infrastructure::notify::late_job_logger::LateJobNotifer;
+use crate::infrastructure::repositories::api_key_repo::ApiKeyRepository;
 use crate::infrastructure::repositories::monitor_repo::MonitorRepository;
 
 use create_monitor::CreateMonitorService;
@@ -53,8 +54,10 @@ pub fn get_process_late_jobs_service(
     ProcessLateJobsService::new(MonitorRepository::new(pool), Default::default())
 }
 
-pub fn get_start_job_service(pool: &DbPool) -> StartJobService<MonitorRepository> {
-    StartJobService::new(MonitorRepository::new(pool))
+pub fn get_start_job_service(
+    pool: &DbPool,
+) -> StartJobService<MonitorRepository, ApiKeyRepository> {
+    StartJobService::new(MonitorRepository::new(pool), ApiKeyRepository::new(pool))
 }
 
 pub fn get_update_monitor_service(pool: &DbPool) -> UpdateMonitorService<MonitorRepository> {

--- a/api/src/application/services/start_job.rs
+++ b/api/src/application/services/start_job.rs
@@ -82,37 +82,17 @@ impl<MonitorRepo: Repository<Monitor>, ApiKeyRepo: Repository<ApiKey> + GetByKey
 
 #[cfg(test)]
 mod tests {
-    use async_trait::async_trait;
-    use mockall::{mock, predicate::*};
+    use mockall::predicate::*;
     use tracing_test::traced_test;
 
     use test_utils::gen_uuid;
     use test_utils::logging::TracingLog;
 
     use crate::domain::models::api_key::ApiKey;
-    use crate::infrastructure::repositories::api_keys::GetByKey;
-    use crate::infrastructure::repositories::{MockRepository, Repository};
+    use crate::infrastructure::repositories::mock_api_key_repo::MockApiKeyRepo;
+    use crate::infrastructure::repositories::MockRepository;
 
     use super::{Error, Monitor, StartJobService};
-
-    mock! {
-        ApiKeyRepo {}
-
-        #[async_trait]
-        impl GetByKey for ApiKeyRepo {
-            async fn get_by_key(&mut self, key: &str) -> Result<Option<ApiKey>, Error>;
-        }
-
-        #[async_trait]
-        impl Repository<ApiKey> for ApiKeyRepo {
-            async fn get(
-                &mut self, api_key_id: uuid::Uuid, tenant: &str
-            ) -> Result<Option<ApiKey>, Error>;
-            async fn all(&mut self, tenant: &str) -> Result<Vec<ApiKey>, Error>;
-            async fn delete(&mut self, key: &ApiKey) -> Result<(), Error>;
-            async fn save(&mut self, key: &ApiKey) -> Result<(), Error>;
-        }
-    }
 
     #[traced_test]
     #[tokio::test]

--- a/api/src/application/services/start_job.rs
+++ b/api/src/application/services/start_job.rs
@@ -1,31 +1,48 @@
 use tracing::info;
 use uuid::Uuid;
 
+use crate::domain::models::api_key::ApiKey;
 use crate::domain::models::job::Job;
 use crate::domain::models::monitor::Monitor;
 use crate::errors::Error;
+use crate::infrastructure::repositories::api_keys::GetByKey;
 use crate::infrastructure::repositories::Repository;
 
-pub struct StartJobService<MonitorRepo: Repository<Monitor>> {
+pub struct StartJobService<
+    MonitorRepo: Repository<Monitor>,
+    ApiKeyRepo: Repository<ApiKey> + GetByKey,
+> {
     monitor_repo: MonitorRepo,
+    api_key_repo: ApiKeyRepo,
 }
 
-impl<MonitorRepo: Repository<Monitor>> StartJobService<MonitorRepo> {
-    pub fn new(monitor_repo: MonitorRepo) -> Self {
-        Self { monitor_repo }
+impl<MonitorRepo: Repository<Monitor>, ApiKeyRepo: Repository<ApiKey> + GetByKey>
+    StartJobService<MonitorRepo, ApiKeyRepo>
+{
+    pub fn new(monitor_repo: MonitorRepo, api_key_repo: ApiKeyRepo) -> Self {
+        Self {
+            monitor_repo,
+            api_key_repo,
+        }
     }
 
     pub async fn start_job_for_monitor(
         &mut self,
         monitor_id: Uuid,
-        tenant: &str,
+        api_key: &str,
     ) -> Result<Job, Error> {
-        let mut monitor_opt = self.monitor_repo.get(monitor_id, tenant).await?;
+        let mut key = self.validate_key(api_key).await?;
+
+        let mut monitor_opt = self.monitor_repo.get(monitor_id, &key.tenant).await?;
 
         match &mut monitor_opt {
             Some(monitor) => {
-                let job = monitor.start_job()?;
-                self.monitor_repo.save(monitor).await?;
+                // Evertime an API key is used to access a monitor, we record it's usage. This is
+                // useful for monitoring and auditing purposes, since API keys aren't as secure as
+                // JWTs.
+                self.record_monitor_usage(&mut key, monitor).await?;
+
+                let job = self.start_job(monitor).await?;
 
                 info!(
                     monitor_id = monitor_id.to_string(),
@@ -38,25 +55,89 @@ impl<MonitorRepo: Repository<Monitor>> StartJobService<MonitorRepo> {
             None => Err(Error::MonitorNotFound(monitor_id)),
         }
     }
+
+    async fn validate_key(&mut self, key: &str) -> Result<ApiKey, Error> {
+        let api_key = self.api_key_repo.get_by_key(key).await?;
+        match api_key {
+            Some(key) => Ok(key),
+            None => Err(Error::Unauthorized("Invalid API key".to_owned())),
+        }
+    }
+
+    async fn record_monitor_usage(
+        &mut self,
+        key: &mut ApiKey,
+        monitor: &Monitor,
+    ) -> Result<(), Error> {
+        key.record_usage(monitor)?;
+        self.api_key_repo.save(key).await
+    }
+
+    async fn start_job(&mut self, monitor: &mut Monitor) -> Result<Job, Error> {
+        let job = monitor.start_job()?;
+        self.monitor_repo.save(monitor).await?;
+        Ok(job)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use mockall::predicate::*;
+    use async_trait::async_trait;
+    use mockall::{mock, predicate::*};
     use tracing_test::traced_test;
 
     use test_utils::gen_uuid;
     use test_utils::logging::TracingLog;
 
-    use crate::infrastructure::repositories::MockRepository;
+    use crate::domain::models::api_key::ApiKey;
+    use crate::infrastructure::repositories::api_keys::GetByKey;
+    use crate::infrastructure::repositories::{MockRepository, Repository};
 
     use super::{Error, Monitor, StartJobService};
+
+    mock! {
+        ApiKeyRepo {}
+
+        #[async_trait]
+        impl GetByKey for ApiKeyRepo {
+            async fn get_by_key(&mut self, key: &str) -> Result<Option<ApiKey>, Error>;
+        }
+
+        #[async_trait]
+        impl Repository<ApiKey> for ApiKeyRepo {
+            async fn get(
+                &mut self, api_key_id: uuid::Uuid, tenant: &str
+            ) -> Result<Option<ApiKey>, Error>;
+            async fn all(&mut self, tenant: &str) -> Result<Vec<ApiKey>, Error>;
+            async fn delete(&mut self, key: &ApiKey) -> Result<(), Error>;
+            async fn save(&mut self, key: &ApiKey) -> Result<(), Error>;
+        }
+    }
 
     #[traced_test]
     #[tokio::test]
     async fn test_start_job_service() {
-        let mut mock = MockRepository::new();
-        mock.expect_get()
+        let mut mock_api_key_repo = MockApiKeyRepo::new();
+        mock_api_key_repo
+            .expect_get_by_key()
+            .once()
+            .with(eq("foo-key"))
+            .returning(|_| Ok(Some(ApiKey::new("foo-key".to_owned(), "tenant".to_owned()))));
+        mock_api_key_repo
+            .expect_save()
+            .once()
+            .withf(|key: &ApiKey| {
+                // We're checking that the key was updated with the last used information.
+                key.last_used.is_some()
+                    && key.last_used_monitor_id
+                        == Some(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"))
+                    && key.last_used_monitor_name == Some("foo".to_owned())
+            })
+            .returning(|_| Ok(()));
+
+        let mut mock_monitor_repo = MockRepository::new();
+        mock_monitor_repo
+            .expect_get()
             .once()
             .with(
                 eq(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")),
@@ -72,7 +153,8 @@ mod tests {
                     jobs: vec![],
                 }))
             });
-        mock.expect_save()
+        mock_monitor_repo
+            .expect_save()
             .once()
             .withf(|monitor: &Monitor| {
                 monitor.monitor_id == gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3")
@@ -82,9 +164,9 @@ mod tests {
             })
             .returning(|_| Ok(()));
 
-        let mut service = StartJobService::new(mock);
+        let mut service = StartJobService::new(mock_monitor_repo, mock_api_key_repo);
         let job = service
-            .start_job_for_monitor(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"), "tenant")
+            .start_job_for_monitor(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"), "foo-key")
             .await
             .unwrap();
 
@@ -109,9 +191,17 @@ mod tests {
 
     #[traced_test]
     #[tokio::test]
-    async fn test_start_job_service_error_handling() {
-        let mut mock = MockRepository::new();
-        mock.expect_get()
+    async fn test_start_job_monitor_not_found() {
+        let mut mock_api_key_repo = MockApiKeyRepo::new();
+        mock_api_key_repo
+            .expect_get_by_key()
+            .once()
+            .with(eq("foo-key"))
+            .returning(|_| Ok(Some(ApiKey::new("foo-key".to_owned(), "tenant".to_owned()))));
+        mock_api_key_repo.expect_save().never();
+        let mut mock_monitor_repo = MockRepository::new();
+        mock_monitor_repo
+            .expect_get()
             .once()
             .with(
                 eq(gen_uuid("01a92c6c-6803-409d-b675-022fff62575a")),
@@ -119,11 +209,11 @@ mod tests {
             )
             .returning(|_, _| Ok(None));
 
-        let mut service = StartJobService::new(mock);
+        let mut service = StartJobService::new(mock_monitor_repo, mock_api_key_repo);
 
         let non_existent_id = gen_uuid("01a92c6c-6803-409d-b675-022fff62575a");
         let start_result = service
-            .start_job_for_monitor(non_existent_id, "tenant")
+            .start_job_for_monitor(non_existent_id, "foo-key")
             .await;
         assert_eq!(start_result, Err(Error::MonitorNotFound(non_existent_id)));
 

--- a/api/src/application/services/start_job.rs
+++ b/api/src/application/services/start_job.rs
@@ -6,13 +6,13 @@ use crate::domain::models::monitor::Monitor;
 use crate::errors::Error;
 use crate::infrastructure::repositories::Repository;
 
-pub struct StartJobService<T: Repository<Monitor>> {
-    repo: T,
+pub struct StartJobService<MonitorRepo: Repository<Monitor>> {
+    monitor_repo: MonitorRepo,
 }
 
-impl<T: Repository<Monitor>> StartJobService<T> {
-    pub fn new(repo: T) -> Self {
-        Self { repo }
+impl<MonitorRepo: Repository<Monitor>> StartJobService<MonitorRepo> {
+    pub fn new(monitor_repo: MonitorRepo) -> Self {
+        Self { monitor_repo }
     }
 
     pub async fn start_job_for_monitor(
@@ -20,12 +20,12 @@ impl<T: Repository<Monitor>> StartJobService<T> {
         monitor_id: Uuid,
         tenant: &str,
     ) -> Result<Job, Error> {
-        let mut monitor_opt = self.repo.get(monitor_id, tenant).await?;
+        let mut monitor_opt = self.monitor_repo.get(monitor_id, tenant).await?;
 
         match &mut monitor_opt {
             Some(monitor) => {
                 let job = monitor.start_job()?;
-                self.repo.save(monitor).await?;
+                self.monitor_repo.save(monitor).await?;
 
                 info!(
                     monitor_id = monitor_id.to_string(),

--- a/api/src/domain/models/api_key.rs
+++ b/api/src/domain/models/api_key.rs
@@ -1,0 +1,98 @@
+use uuid::Uuid;
+
+use chrono::{NaiveDateTime, Utc};
+use serde::Serialize;
+
+use super::monitor::Monitor;
+use crate::errors::Error;
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ApiKey {
+    /// The unique identifier for the API key.
+    pub api_key_id: Uuid,
+    /// The tenant that the API key belongs to.
+    pub tenant: String,
+    /// The API key value.
+    #[serde(skip_serializing)]
+    pub key: String,
+    /// The last time the API key was used.
+    pub last_used: Option<NaiveDateTime>,
+    /// The unique identifier of the monitor that last used the API key.
+    pub last_used_monitor_id: Option<Uuid>,
+    /// The name of the monitor that last used the API key.
+    pub last_used_monitor_name: Option<String>,
+}
+
+impl ApiKey {
+    /// Create a new API key.
+    pub fn new(key: String, tenant: String) -> Self {
+        Self {
+            api_key_id: Uuid::new_v4(),
+            tenant,
+            key,
+            last_used: None,
+            last_used_monitor_id: None,
+            last_used_monitor_name: None,
+        }
+    }
+
+    pub fn record_usage(&mut self, monitor: &Monitor) -> Result<(), Error> {
+        if self.tenant != monitor.tenant {
+            return Err(Error::Unauthorized(
+                "Monitor does not belong to this tenant".to_owned(),
+            ));
+        }
+
+        self.last_used = Some(Utc::now().naive_utc());
+        self.last_used_monitor_id = Some(monitor.monitor_id);
+        self.last_used_monitor_name = Some(monitor.name.clone());
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Timelike, Utc};
+    use pretty_assertions::assert_eq;
+    use test_utils::gen_uuid;
+
+    use super::ApiKey;
+    use crate::domain::models::monitor::Monitor;
+
+    #[tokio::test(start_paused = true)]
+    async fn test_record_usage() {
+        let mut key = ApiKey::new("test".to_owned(), "tenant".to_owned());
+        assert_eq!(
+            key,
+            ApiKey {
+                api_key_id: key.api_key_id, // Can't predict this, but it's not important.
+                tenant: "tenant".to_owned(),
+                key: "test".to_owned(),
+                last_used: None,
+                last_used_monitor_id: None,
+                last_used_monitor_name: None,
+            }
+        );
+
+        let monitor = Monitor {
+            monitor_id: gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"),
+            tenant: "tenant".to_owned(),
+            name: "foo".to_owned(),
+            expected_duration: 300,
+            grace_duration: 10,
+            jobs: vec![],
+        };
+
+        assert!(key.record_usage(&monitor).is_ok());
+        assert_eq!(
+            key.last_used_monitor_id,
+            Some(gen_uuid("41ebffb4-a188-48e9-8ec1-61380085cde3"))
+        );
+        assert_eq!(key.last_used_monitor_name, Some("foo".to_owned()));
+        assert_eq!(
+            key.last_used.unwrap().with_nanosecond(0).unwrap(),
+            Utc::now().naive_utc().with_nanosecond(0).unwrap()
+        );
+    }
+}

--- a/api/src/domain/models/job.rs
+++ b/api/src/domain/models/job.rs
@@ -1,5 +1,4 @@
-use chrono::NaiveDateTime;
-use chrono::{offset::Utc, Duration};
+use chrono::{Duration, NaiveDateTime, Utc};
 use serde::{Serialize, Serializer};
 use uuid::Uuid;
 

--- a/api/src/domain/models/mod.rs
+++ b/api/src/domain/models/mod.rs
@@ -1,2 +1,3 @@
+pub mod api_key;
 pub mod job;
 pub mod monitor;

--- a/api/src/infrastructure/db_schema.rs
+++ b/api/src/infrastructure/db_schema.rs
@@ -1,6 +1,19 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    api_key (api_key_id) {
+        api_key_id -> Uuid,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+        key -> Varchar,
+        tenant -> Varchar,
+        last_used -> Nullable<Timestamp>,
+        last_used_monitor_id -> Nullable<Uuid>,
+        last_used_monitor_name -> Nullable<Varchar>,
+    }
+}
+
+diesel::table! {
     job (job_id) {
         job_id -> Uuid,
         created_at -> Timestamp,
@@ -28,4 +41,4 @@ diesel::table! {
 
 diesel::joinable!(job -> monitor (monitor_id));
 
-diesel::allow_tables_to_appear_in_same_query!(job, monitor,);
+diesel::allow_tables_to_appear_in_same_query!(api_key, job, monitor);

--- a/api/src/infrastructure/middleware/guards/api_key.rs
+++ b/api/src/infrastructure/middleware/guards/api_key.rs
@@ -1,0 +1,64 @@
+use async_trait::async_trait;
+use rocket::http::Status;
+use rocket::request::{FromRequest, Outcome, Request};
+
+use crate::errors::Error;
+
+pub struct ApiKey(pub String);
+
+#[async_trait]
+impl<'r> FromRequest<'r> for ApiKey {
+    type Error = Error;
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        match request.headers().get_one("X-API-Key") {
+            Some(key) => Outcome::Success(ApiKey(key.to_owned())),
+            None => Outcome::Error((
+                Status::Unauthorized,
+                Error::Unauthorized("X-API-Key is required".to_string()),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocket::http::Accept;
+    use rocket::http::Header;
+    use rocket::http::Status;
+    use rocket::local::blocking::Client;
+    use rstest::{fixture, rstest};
+
+    use super::ApiKey;
+
+    #[fixture]
+    fn client() -> Client {
+        #[rocket::get("/")]
+        async fn protected_index(api_key: ApiKey) -> String {
+            format!("API key: {}", api_key.0)
+        }
+
+        let test_rocket = rocket::build().mount("/", rocket::routes![protected_index]);
+        Client::tracked(test_rocket)
+            .expect("Couldn't create test Rocket app for ApiKey request guard test")
+    }
+
+    #[rstest]
+    fn test_api_key_provided(client: Client) {
+        let response = client
+            .get("/")
+            .header(Accept::JSON)
+            .header(Header::new("X-Api-Key", "foo-key"))
+            .dispatch();
+
+        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.into_string().unwrap(), "API key: foo-key");
+    }
+
+    #[rstest]
+    fn test_api_key_not_provided(client: Client) {
+        let response = client.get("/").header(Accept::JSON).dispatch();
+
+        assert_eq!(response.status(), Status::Unauthorized);
+    }
+}

--- a/api/src/infrastructure/middleware/guards/jwt.rs
+++ b/api/src/infrastructure/middleware/guards/jwt.rs
@@ -81,7 +81,7 @@ mod tests {
         // Setup a Rocket client that doesn't have a JwtAuth service at all.
         let test_rocket = rocket::build().mount("/", rocket::routes![protected_index]);
         let client = Client::tracked(test_rocket)
-            .expect("Couldn't create test Rocket app for DefaultJSON fairing test");
+            .expect("Couldn't create test Rocket app for Jwt request guard test");
 
         let response = client
             .get("/")
@@ -225,6 +225,6 @@ mod tests {
             .manage(Box::new(mock) as Box<dyn JwtAuth + Send + Sync>)
             .mount("/", rocket::routes![protected_index]);
         Client::tracked(test_rocket)
-            .expect("Couldn't create test Rocket app for DefaultJSON fairing test")
+            .expect("Couldn't create test Rocket app for Jwt request guard test")
     }
 }

--- a/api/src/infrastructure/middleware/guards/mod.rs
+++ b/api/src/infrastructure/middleware/guards/mod.rs
@@ -1,1 +1,2 @@
+pub mod api_key;
 pub mod jwt;

--- a/api/src/infrastructure/middleware/response.rs
+++ b/api/src/infrastructure/middleware/response.rs
@@ -88,7 +88,7 @@ mod tests {
         Err(Error::Unauthorized("insufficient permissions".to_string()))
     }
 
-    #[rocket::get("/auth_erpr")]
+    #[rocket::get("/auth_error")]
     fn auth_error() -> Result<(), Error> {
         Err(Error::AuthenticationError(
             "something went wrong".to_string(),
@@ -245,7 +245,7 @@ mod tests {
 
     #[rstest]
     fn test_authentication_error(test_client: Client) {
-        let response = test_client.get("/auth_erpr").dispatch();
+        let response = test_client.get("/auth_error").dispatch();
 
         assert_eq!(response.status(), Status::InternalServerError);
         assert_eq!(response.content_type(), Some(ContentType::JSON));

--- a/api/src/infrastructure/migrations/2024-10-06-200728_add_api_key_table/down.sql
+++ b/api/src/infrastructure/migrations/2024-10-06-200728_add_api_key_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE api_key;

--- a/api/src/infrastructure/migrations/2024-10-06-200728_add_api_key_table/up.sql
+++ b/api/src/infrastructure/migrations/2024-10-06-200728_add_api_key_table/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE api_key (
+	api_key_id uuid PRIMARY KEY,
+	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	key VARCHAR NOT NULL,
+	tenant VARCHAR NOT NULL,
+    last_used TIMESTAMP NULL,
+	last_used_monitor_id uuid NULL,
+    last_used_monitor_name VARCHAR NULL
+);
+SELECT diesel_manage_updated_at('api_key');

--- a/api/src/infrastructure/models/api_key.rs
+++ b/api/src/infrastructure/models/api_key.rs
@@ -1,0 +1,116 @@
+use chrono::NaiveDateTime;
+use diesel::prelude::*;
+use uuid::Uuid;
+
+use crate::domain::models::api_key::ApiKey;
+use crate::infrastructure::db_schema::api_key;
+
+// Note that we do not have a corresponding domain model for ApiKeyData, like we do for monitors and
+// jobs. This is because the ApiKeyData struct is a direct representation of the database table, and
+// we do not need to transform it into a domain model.
+#[derive(Clone, Queryable, Identifiable, Selectable, Insertable, AsChangeset)]
+#[diesel(table_name = api_key)]
+#[diesel(primary_key(api_key_id))]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ApiKeyData {
+    pub api_key_id: Uuid,
+    pub tenant: String,
+    pub key: String,
+    pub last_used: Option<NaiveDateTime>,
+    pub last_used_monitor_id: Option<Uuid>,
+    pub last_used_monitor_name: Option<String>,
+}
+
+impl From<&ApiKeyData> for ApiKey {
+    fn from(value: &ApiKeyData) -> Self {
+        ApiKey {
+            api_key_id: value.api_key_id,
+            tenant: value.tenant.clone(),
+            key: value.key.clone(),
+            last_used: value.last_used,
+            last_used_monitor_id: value.last_used_monitor_id,
+            last_used_monitor_name: value.last_used_monitor_name.clone(),
+        }
+    }
+}
+
+impl From<&ApiKey> for ApiKeyData {
+    fn from(value: &ApiKey) -> Self {
+        ApiKeyData {
+            api_key_id: value.api_key_id,
+            tenant: value.tenant.clone(),
+            key: value.key.clone(),
+            last_used: value.last_used,
+            last_used_monitor_id: value.last_used_monitor_id,
+            last_used_monitor_name: value.last_used_monitor_name.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use test_utils::{gen_relative_datetime, gen_uuid};
+
+    use super::{ApiKey, ApiKeyData};
+
+    #[test]
+    fn test_from_api_key_data() {
+        let api_key_id = gen_uuid("fadd7266-648b-4102-8f85-c768655f4297");
+        let tenant = "test-tenant".to_owned();
+        let key = "test-key".to_owned();
+        let last_used = Some(gen_relative_datetime(0));
+        let last_used_monitor_id = Some(gen_uuid("8c8e7032-5de9-4dcf-b267-4e66e27b8a78"));
+        let last_used_monitor_name = Some("test-monitor".to_owned());
+
+        let data = ApiKeyData {
+            api_key_id,
+            tenant: tenant.clone(),
+            key: key.clone(),
+            last_used,
+            last_used_monitor_id,
+            last_used_monitor_name: last_used_monitor_name.clone(),
+        };
+
+        let model = ApiKey {
+            api_key_id,
+            tenant,
+            key,
+            last_used,
+            last_used_monitor_id,
+            last_used_monitor_name,
+        };
+
+        assert_eq!(ApiKey::from(&data), model);
+    }
+
+    #[test]
+    fn test_to_api_key_data() {
+        let api_key_id = gen_uuid("fadd7266-648b-4102-8f85-c768655f4297");
+        let tenant = "test-tenant".to_owned();
+        let key = "test-key".to_owned();
+        let last_used = Some(gen_relative_datetime(0));
+        let last_used_monitor_id = Some(gen_uuid("8c8e7032-5de9-4dcf-b267-4e66e27b8a78"));
+        let last_used_monitor_name = Some("test-monitor".to_owned());
+
+        let model = ApiKey {
+            api_key_id,
+            tenant: tenant.clone(),
+            key: key.clone(),
+            last_used,
+            last_used_monitor_id,
+            last_used_monitor_name: last_used_monitor_name.clone(),
+        };
+
+        let data = ApiKeyData {
+            api_key_id,
+            tenant,
+            key,
+            last_used,
+            last_used_monitor_id,
+            last_used_monitor_name,
+        };
+
+        assert_eq!(ApiKey::from(&data), model);
+    }
+}

--- a/api/src/infrastructure/models/mod.rs
+++ b/api/src/infrastructure/models/mod.rs
@@ -1,2 +1,3 @@
+pub mod api_key;
 pub mod job;
 pub mod monitor;

--- a/api/src/infrastructure/repositories/api_key_repo.rs
+++ b/api/src/infrastructure/repositories/api_key_repo.rs
@@ -1,0 +1,149 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use diesel::prelude::*;
+use diesel::result::Error as DieselError;
+use diesel_async::pooled_connection::deadpool::Object;
+use diesel_async::AsyncConnection;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use uuid::Uuid;
+
+use crate::domain::models::api_key::ApiKey;
+use crate::errors::Error;
+use crate::infrastructure::database::DbPool;
+use crate::infrastructure::db_schema::api_key;
+use crate::infrastructure::models::api_key::ApiKeyData;
+use crate::infrastructure::repositories::api_keys::GetByKey;
+use crate::infrastructure::repositories::Repository;
+
+pub struct ApiKeyRepository<'a> {
+    pool: &'a DbPool,
+    data: HashMap<Uuid, ApiKeyData>,
+}
+
+impl<'a> ApiKeyRepository<'a> {
+    pub fn new(pool: &'a DbPool) -> Self {
+        Self {
+            pool,
+            data: HashMap::new(),
+        }
+    }
+
+    async fn get_connection(&mut self) -> Result<Object<AsyncPgConnection>, Error> {
+        self.pool
+            .get()
+            .await
+            .map_err(|e| Error::RepositoryError(e.to_string()))
+    }
+
+    fn db_to_key(&mut self, key: &ApiKeyData) -> ApiKey {
+        let api_key = ApiKey::from(key);
+        self.data.insert(key.api_key_id, key.clone());
+        api_key
+    }
+}
+
+#[async_trait]
+impl<'a> GetByKey for ApiKeyRepository<'a> {
+    async fn get_by_key(&mut self, key: &str) -> Result<Option<ApiKey>, Error> {
+        let mut connection = self.get_connection().await?;
+        connection
+            .transaction::<Option<ApiKey>, DieselError, _>(|conn| {
+                Box::pin(async move {
+                    let api_key = api_key::table
+                        .filter(api_key::key.eq(key))
+                        .select(ApiKeyData::as_select())
+                        .first(conn)
+                        .await
+                        .optional()?;
+
+                    Ok(api_key.map(|key| self.db_to_key(&key)))
+                })
+            })
+            .await
+            .map_err(|err| Error::RepositoryError(err.to_string()))
+    }
+}
+
+#[async_trait]
+impl<'a> Repository<ApiKey> for ApiKeyRepository<'a> {
+    async fn get(&mut self, api_key_id: Uuid, tenant: &str) -> Result<Option<ApiKey>, Error> {
+        let mut connection = self.get_connection().await?;
+        connection
+            .transaction::<Option<ApiKey>, DieselError, _>(|conn| {
+                Box::pin(async move {
+                    let api_key = api_key::table
+                        .select(ApiKeyData::as_select())
+                        .filter(
+                            api_key::api_key_id
+                                .eq(api_key_id)
+                                .and(api_key::tenant.eq(tenant)),
+                        )
+                        .first(conn)
+                        .await
+                        .optional()?;
+
+                    Ok(api_key.map(|key| self.db_to_key(&key)))
+                })
+            })
+            .await
+            .map_err(|err| Error::RepositoryError(err.to_string()))
+    }
+
+    async fn all(&mut self, tenant: &str) -> Result<Vec<ApiKey>, Error> {
+        let mut connection = self.get_connection().await?;
+        connection
+            .transaction::<Vec<ApiKey>, DieselError, _>(|conn| {
+                Box::pin(async move {
+                    let api_keys = api_key::table
+                        .select(ApiKeyData::as_select())
+                        .filter(api_key::tenant.eq(tenant))
+                        .load(conn)
+                        .await?;
+
+                    Ok(api_keys.into_iter().map(|k| self.db_to_key(&k)).collect())
+                })
+            })
+            .await
+            .map_err(|err| Error::RepositoryError(err.to_string()))
+    }
+
+    async fn save(&mut self, key: &ApiKey) -> Result<(), Error> {
+        let mut connection = self.get_connection().await?;
+        connection
+            .transaction::<(), DieselError, _>(|conn| {
+                Box::pin(async move {
+                    let api_key_data = ApiKeyData::from(key);
+                    if let Some(_cached) = self.data.get(&api_key_data.api_key_id) {
+                        diesel::update(&api_key_data)
+                            .set(&api_key_data)
+                            .execute(conn)
+                            .await?;
+                    } else {
+                        diesel::insert_into(api_key::table)
+                            .values(&api_key_data)
+                            .execute(conn)
+                            .await?;
+                    }
+
+                    self.db_to_key(&api_key_data);
+
+                    Ok(())
+                })
+            })
+            .await
+            .map_err(|err| Error::RepositoryError(err.to_string()))
+    }
+
+    async fn delete(&mut self, key: &ApiKey) -> Result<(), Error> {
+        let api_key_data = ApiKeyData::from(key);
+        let mut connection = self.get_connection().await?;
+        diesel::delete(&api_key_data)
+            .execute(&mut connection)
+            .await
+            .map_err(|err| Error::RepositoryError(err.to_string()))?;
+
+        self.data.remove(&key.api_key_id);
+        Ok(())
+    }
+}

--- a/api/src/infrastructure/repositories/api_keys.rs
+++ b/api/src/infrastructure/repositories/api_keys.rs
@@ -1,0 +1,13 @@
+use async_trait::async_trait;
+
+#[cfg(test)]
+use mockall::automock;
+
+use crate::domain::models::api_key::ApiKey;
+use crate::errors::Error;
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait GetByKey {
+    async fn get_by_key(&mut self, key: &str) -> Result<Option<ApiKey>, Error>;
+}

--- a/api/src/infrastructure/repositories/mock_api_key_repo.rs
+++ b/api/src/infrastructure/repositories/mock_api_key_repo.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+use mockall::mock;
+
+use crate::domain::models::api_key::ApiKey;
+use crate::errors::Error;
+use crate::infrastructure::repositories::api_keys::GetByKey;
+use crate::infrastructure::repositories::Repository;
+
+mock! {
+    pub ApiKeyRepo {}
+
+    #[async_trait]
+    impl GetByKey for ApiKeyRepo {
+        async fn get_by_key(&mut self, key: &str) -> Result<Option<ApiKey>, Error>;
+    }
+
+    #[async_trait]
+    impl Repository<ApiKey> for ApiKeyRepo {
+        async fn get(
+            &mut self, api_key_id: uuid::Uuid, tenant: &str
+        ) -> Result<Option<ApiKey>, Error>;
+        async fn all(&mut self, tenant: &str) -> Result<Vec<ApiKey>, Error>;
+        async fn delete(&mut self, key: &ApiKey) -> Result<(), Error>;
+        async fn save(&mut self, key: &ApiKey) -> Result<(), Error>;
+    }
+}

--- a/api/src/infrastructure/repositories/mod.rs
+++ b/api/src/infrastructure/repositories/mod.rs
@@ -3,6 +3,9 @@ pub mod api_keys;
 pub mod monitor;
 pub mod monitor_repo;
 
+#[cfg(test)]
+pub mod mock_api_key_repo;
+
 use std::marker::{Send, Sync};
 
 use async_trait::async_trait;

--- a/api/src/infrastructure/repositories/mod.rs
+++ b/api/src/infrastructure/repositories/mod.rs
@@ -1,3 +1,5 @@
+pub mod api_key_repo;
+pub mod api_keys;
 pub mod monitor;
 pub mod monitor_repo;
 

--- a/api/src/infrastructure/seeding/seeds.sql
+++ b/api/src/infrastructure/seeding/seeds.sql
@@ -1,6 +1,7 @@
 -- Remove all existing data to ensure seeding doesn't fail due to unique constraints.
 DELETE FROM job;
 DELETE FROM monitor;
+DELETE FROM api_key;
 
 -- Monitors.
 INSERT INTO monitor
@@ -174,3 +175,9 @@ VALUES
         TRUE,
         '{"bills_processed": 1234, "invoiced_generated": 325}'
     );
+
+-- API keys.
+INSERT INTO api_key
+    (api_key_id, tenant, key)
+VALUES
+    ('270e1d61-baf2-4f29-a04f-eee956da8f9e', 'cron-mon', 'YWI0Y2FkMTAtMmJmZi00MjMyLWE5MTEtNzQyZWU0NjY4ZjI1Cg==');

--- a/api/tests/api_key_repo_test.rs
+++ b/api/tests/api_key_repo_test.rs
@@ -1,0 +1,117 @@
+pub mod common;
+
+use pretty_assertions::assert_eq;
+
+use test_utils::gen_uuid;
+
+use cron_mon_api::domain::models::api_key::ApiKey;
+use cron_mon_api::infrastructure::repositories::api_key_repo::ApiKeyRepository;
+use cron_mon_api::infrastructure::repositories::api_keys::GetByKey;
+use cron_mon_api::infrastructure::repositories::Repository;
+
+use common::setup_db_pool;
+
+#[tokio::test]
+async fn test_all() {
+    // See data seeds for the expected data (/api/tests/common/mod.rs)
+    let pool = setup_db_pool().await;
+    let mut repo = ApiKeyRepository::new(&pool);
+
+    let keys = repo.all("foo").await.unwrap();
+
+    let keys: Vec<String> = keys.iter().map(|key| key.key.clone()).collect();
+    assert_eq!(keys, vec!["foo-key", "bar-key"]);
+}
+
+#[tokio::test]
+async fn test_get() {
+    let pool = setup_db_pool().await;
+    let mut repo = ApiKeyRepository::new(&pool);
+
+    let non_existent_api_key_id = repo
+        .get(gen_uuid("4940ede2-72fc-4e0e-838e-f15f35e3594f"), "foo")
+        .await
+        .unwrap();
+    let wrong_tenant = repo
+        .get(gen_uuid("bfab6d41-8b00-49ef-86df-f562b701ee4f"), "bar")
+        .await
+        .unwrap();
+    let should_be_some = repo
+        .get(gen_uuid("bfab6d41-8b00-49ef-86df-f562b701ee4f"), "foo")
+        .await
+        .unwrap();
+
+    assert!(non_existent_api_key_id.is_none());
+    assert!(wrong_tenant.is_none());
+    assert!(should_be_some.is_some());
+
+    let key = should_be_some.unwrap();
+    assert_eq!(key.key, "foo-key");
+}
+
+#[tokio::test]
+async fn test_get_by_key() {
+    let pool = setup_db_pool().await;
+    let mut repo = ApiKeyRepository::new(&pool);
+
+    let existent_key = repo.get_by_key("foo-key").await.unwrap();
+    let non_existent_key = repo.get_by_key("non-existent").await.unwrap();
+
+    assert!(existent_key.is_some());
+    assert_eq!(
+        existent_key.unwrap().api_key_id,
+        gen_uuid("bfab6d41-8b00-49ef-86df-f562b701ee4f")
+    );
+
+    assert!(non_existent_key.is_none());
+}
+
+#[tokio::test]
+async fn test_save() {
+    let pool = setup_db_pool().await;
+    let mut repo = ApiKeyRepository::new(&pool);
+
+    let new_api_key = ApiKey {
+        api_key_id: gen_uuid("d2b291fe-bd41-4787-bc2d-1329903f7a6a"),
+        tenant: "foo".to_string(),
+        key: "new-key".to_string(),
+        last_used: None,
+        last_used_monitor_id: None,
+        last_used_monitor_name: None,
+    };
+    repo.save(&new_api_key).await.unwrap();
+    assert_eq!(repo.all("foo").await.unwrap().len(), 3);
+
+    let read_new_api_key = repo
+        .get(new_api_key.api_key_id, "foo")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(new_api_key.api_key_id, read_new_api_key.api_key_id);
+    assert_eq!(new_api_key.key, read_new_api_key.key);
+    assert_eq!(new_api_key.last_used, read_new_api_key.last_used);
+    assert_eq!(
+        new_api_key.last_used_monitor_id,
+        read_new_api_key.last_used_monitor_id
+    );
+    assert_eq!(
+        new_api_key.last_used_monitor_name,
+        read_new_api_key.last_used_monitor_name
+    );
+}
+
+#[tokio::test]
+async fn test_delete() {
+    let pool = setup_db_pool().await;
+    let mut repo = ApiKeyRepository::new(&pool);
+
+    let key = repo
+        .get(gen_uuid("bfab6d41-8b00-49ef-86df-f562b701ee4f"), "foo")
+        .await
+        .unwrap()
+        .unwrap();
+
+    repo.delete(&key).await.unwrap();
+    assert!(repo.get(key.api_key_id, "foo").await.unwrap().is_none());
+    assert_eq!(repo.all("foo").await.unwrap().len(), 1);
+}

--- a/api/tests/api_key_routes_test.rs
+++ b/api/tests/api_key_routes_test.rs
@@ -1,0 +1,77 @@
+pub mod common;
+
+use pretty_assertions::assert_eq;
+use rocket::http::{ContentType, Header, Status};
+use rocket::local::asynchronous::LocalResponse;
+use serde_json::{json, Value};
+
+use common::get_test_client;
+
+#[tokio::test]
+async fn test_start_job_with_no_api_key() {
+    let (_mock_server, client) = get_test_client("test-kid", false).await;
+
+    let response = client
+        .post("/api/v1/monitors/c1bf0515-df39-448b-aa95-686360a33b36/jobs/start")
+        .dispatch()
+        .await;
+
+    assert_response_is_unauthorized(response, "The request requires user authentication.").await;
+}
+
+#[tokio::test]
+async fn test_start_job_with_invalid_api_key() {
+    let (_mock_server, client) = get_test_client("test-kid", false).await;
+
+    let response = client
+        .post("/api/v1/monitors/c1bf0515-df39-448b-aa95-686360a33b36/jobs/start")
+        .header(Header::new("X-API-Key", "invalid-key"))
+        .dispatch()
+        .await;
+
+    assert_response_is_unauthorized(response, "Unauthorized: Invalid API key").await;
+}
+
+#[tokio::test]
+async fn test_finish_job_with_no_api_key() {
+    let (_mock_server, client) = get_test_client("test-kid", false).await;
+
+    let response = client
+        .post("/api/v1/monitors/c1bf0515-df39-448b-aa95-686360a33b36/jobs/9d4e2d69-af63-4c1e-8639-60cb2683aee5/finish")
+        .json(&json!({"succeeded": true, "output": "Test output"}))
+        .dispatch()
+        .await;
+
+    assert_response_is_unauthorized(response, "The request requires user authentication.").await;
+}
+
+#[tokio::test]
+async fn test_finish_job_with_invalid_api_key() {
+    let (_mock_server, client) = get_test_client("test-kid", false).await;
+
+    let response = client
+        .post("/api/v1/monitors/c1bf0515-df39-448b-aa95-686360a33b36/jobs/9d4e2d69-af63-4c1e-8639-60cb2683aee5/finish")
+        .header(Header::new("X-API-Key", "invalid-key"))
+        .json(&json!({"succeeded": true, "output": "Test output"}))
+        .dispatch()
+        .await;
+
+    assert_response_is_unauthorized(response, "Unauthorized: Invalid API key").await;
+}
+
+async fn assert_response_is_unauthorized(response: LocalResponse<'_>, description: &str) {
+    assert_eq!(response.status(), Status::Unauthorized);
+    assert_eq!(response.content_type(), Some(ContentType::JSON));
+
+    let response_body = response.into_json::<Value>().await.unwrap();
+    assert_eq!(
+        response_body,
+        json!({
+            "error": {
+                "code": 401,
+                "description": description,
+                "reason": "Unauthorized"
+            }
+        })
+    );
+}

--- a/api/tests/jobs_routes_test.rs
+++ b/api/tests/jobs_routes_test.rs
@@ -1,7 +1,7 @@
 pub mod common;
 
 use pretty_assertions::assert_eq;
-use rocket::http::{ContentType, Status};
+use rocket::http::{ContentType, Header, Status};
 use rocket::local::asynchronous::Client;
 use rstest::*;
 use serde_json::{json, Value};
@@ -71,7 +71,7 @@ async fn test_start_job() {
 
     let response = client
         .post("/api/v1/monitors/c1bf0515-df39-448b-aa95-686360a33b36/jobs/start")
-        .json(&json!({"tenant": "foo"}))
+        .header(Header::new("X-API-Key", "foo-key"))
         .dispatch()
         .await;
 

--- a/api/tests/jobs_routes_test.rs
+++ b/api/tests/jobs_routes_test.rs
@@ -96,7 +96,8 @@ async fn test_finish_job() {
             "/api/v1/monitors/c1bf0515-df39-448b-aa95-686360a33b36\
             /jobs/9d4e2d69-af63-4c1e-8639-60cb2683aee5/finish",
         )
-        .json(&json!({"succeeded": true, "output": "Test output", "tenant": "foo"}))
+        .header(Header::new("X-API-Key", "foo-key"))
+        .json(&json!({"succeeded": true, "output": "Test output"}))
         .dispatch()
         .await;
 
@@ -151,7 +152,8 @@ async fn test_finish_job_errors(
             "/api/v1/monitors/c1bf0515-df39-448b-aa95-686360a33b36/jobs/{}/finish",
             job_id
         ))
-        .json(&json!({"succeeded": true, "output": "Test output", "tenant": "foo"}))
+        .header(Header::new("X-API-Key", "foo-key"))
+        .json(&json!({"succeeded": true, "output": "Test output"}))
         .dispatch()
         .await;
 

--- a/api/tests/monitor_repo_test.rs
+++ b/api/tests/monitor_repo_test.rs
@@ -157,6 +157,7 @@ async fn test_loading_invalid_job() {
             succeeded: Some(true),
             output: Some("Database successfully backed up".to_string()),
         }],
+        &vec![],
     )
     .await;
 


### PR DESCRIPTION
Setup API keys in the DB and use them to authenticate starting and finishing jobs. Note there is currently no way to create API keys other than to do so manually in the DB - CRUD endpoints for API keys will be added in a subsequent PR.

Relates to #22 