### PR TITLE
Feat/no raw keys in db

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "sha2",
  "signal-hook",
  "test-utils",
  "tokio",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = { version = "0.12.8", features = ["json"] }
 rocket = { version = "0.5.1", features = ["json", "uuid"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10.8"
 signal-hook = "0.3.17"
 tokio = { version = "1.40.0", features = ["test-util"] }
 tracing = "0.1.40"

--- a/api/src/application/services/finish_job.rs
+++ b/api/src/application/services/finish_job.rs
@@ -60,7 +60,7 @@ impl<MonitorRepo: Repository<Monitor>, ApiKeyRepo: Repository<ApiKey> + GetByKey
     }
 
     async fn validate_key(&mut self, key: &str) -> Result<ApiKey, Error> {
-        let api_key = self.api_key_repo.get_by_key(key).await?;
+        let api_key = self.api_key_repo.get_by_key(&ApiKey::hash_key(key)).await?;
         match api_key {
             Some(key) => Ok(key),
             None => Err(Error::Unauthorized("Invalid API key".to_owned())),
@@ -191,7 +191,9 @@ mod tests {
         mock_api_key_repo
             .expect_get_by_key()
             .once()
-            .with(eq("foo-key"))
+            .with(eq(
+                "104e4587f5340bd9264ea0fee2075627c74420bd5c48aa9e8a463f03a2675020",
+            ))
             .returning(|_| Ok(None));
 
         let mut service = FinishJobService::new(MockRepository::new(), mock_api_key_repo);
@@ -223,7 +225,9 @@ mod tests {
         mock_api_key_repo
             .expect_get_by_key()
             .once()
-            .with(eq("foo-key"))
+            .with(eq(
+                "104e4587f5340bd9264ea0fee2075627c74420bd5c48aa9e8a463f03a2675020",
+            ))
             .returning(|_| Ok(Some(ApiKey::new("foo-key".to_owned(), "tenant".to_owned()))));
         mock_api_key_repo.expect_save().never();
 
@@ -387,7 +391,9 @@ mod tests {
         mock_api_key_repo
             .expect_get_by_key()
             .once()
-            .with(eq("foo-key"))
+            .with(eq(
+                "104e4587f5340bd9264ea0fee2075627c74420bd5c48aa9e8a463f03a2675020",
+            ))
             .returning(|_| Ok(Some(ApiKey::new("foo-key".to_owned(), "tenant".to_owned()))));
         mock_api_key_repo
             .expect_save()

--- a/api/src/application/services/start_job.rs
+++ b/api/src/application/services/start_job.rs
@@ -57,7 +57,7 @@ impl<MonitorRepo: Repository<Monitor>, ApiKeyRepo: Repository<ApiKey> + GetByKey
     }
 
     async fn validate_key(&mut self, key: &str) -> Result<ApiKey, Error> {
-        let api_key = self.api_key_repo.get_by_key(key).await?;
+        let api_key = self.api_key_repo.get_by_key(&ApiKey::hash_key(key)).await?;
         match api_key {
             Some(key) => Ok(key),
             None => Err(Error::Unauthorized("Invalid API key".to_owned())),
@@ -101,7 +101,9 @@ mod tests {
         mock_api_key_repo
             .expect_get_by_key()
             .once()
-            .with(eq("foo-key"))
+            .with(eq(
+                "104e4587f5340bd9264ea0fee2075627c74420bd5c48aa9e8a463f03a2675020",
+            ))
             .returning(|_| Ok(Some(ApiKey::new("foo-key".to_owned(), "tenant".to_owned()))));
         mock_api_key_repo
             .expect_save()
@@ -176,7 +178,9 @@ mod tests {
         mock_api_key_repo
             .expect_get_by_key()
             .once()
-            .with(eq("foo-key"))
+            .with(eq(
+                "104e4587f5340bd9264ea0fee2075627c74420bd5c48aa9e8a463f03a2675020",
+            ))
             .returning(|_| Ok(None));
 
         let mut service = StartJobService::new(MockRepository::new(), mock_api_key_repo);
@@ -201,7 +205,9 @@ mod tests {
         mock_api_key_repo
             .expect_get_by_key()
             .once()
-            .with(eq("foo-key"))
+            .with(eq(
+                "104e4587f5340bd9264ea0fee2075627c74420bd5c48aa9e8a463f03a2675020",
+            ))
             .returning(|_| Ok(Some(ApiKey::new("foo-key".to_owned(), "tenant".to_owned()))));
         mock_api_key_repo.expect_save().never();
         let mut mock_monitor_repo = MockRepository::new();

--- a/api/src/infrastructure/seeding/seeds.sql
+++ b/api/src/infrastructure/seeding/seeds.sql
@@ -180,4 +180,8 @@ VALUES
 INSERT INTO api_key
     (api_key_id, tenant, key)
 VALUES
-    ('270e1d61-baf2-4f29-a04f-eee956da8f9e', 'cron-mon', 'YWI0Y2FkMTAtMmJmZi00MjMyLWE5MTEtNzQyZWU0NjY4ZjI1Cg==');
+    (
+        '270e1d61-baf2-4f29-a04f-eee956da8f9e',
+        'cron-mon',
+        'a759f35ec8a03a97f707e7a6094362d971e2ff114b201f0567563fb0a1b972db'
+    );

--- a/api/tests/api_key_repo_test.rs
+++ b/api/tests/api_key_repo_test.rs
@@ -20,7 +20,13 @@ async fn test_all() {
     let keys = repo.all("foo").await.unwrap();
 
     let keys: Vec<String> = keys.iter().map(|key| key.key.clone()).collect();
-    assert_eq!(keys, vec!["foo-key", "bar-key"]);
+    assert_eq!(
+        keys,
+        vec![
+            "104e4587f5340bd9264ea0fee2075627c74420bd5c48aa9e8a463f03a2675020",
+            "a3dd31a59c493fcbb87c1b7acfa1770740de6a712e11337648f42d64420ff4bc"
+        ]
+    );
 }
 
 #[tokio::test]
@@ -46,7 +52,10 @@ async fn test_get() {
     assert!(should_be_some.is_some());
 
     let key = should_be_some.unwrap();
-    assert_eq!(key.key, "foo-key");
+    assert_eq!(
+        key.key,
+        "104e4587f5340bd9264ea0fee2075627c74420bd5c48aa9e8a463f03a2675020"
+    );
 }
 
 #[tokio::test]
@@ -54,7 +63,10 @@ async fn test_get_by_key() {
     let pool = setup_db_pool().await;
     let mut repo = ApiKeyRepository::new(&pool);
 
-    let existent_key = repo.get_by_key("foo-key").await.unwrap();
+    let existent_key = repo
+        .get_by_key("104e4587f5340bd9264ea0fee2075627c74420bd5c48aa9e8a463f03a2675020")
+        .await
+        .unwrap();
     let non_existent_key = repo.get_by_key("non-existent").await.unwrap();
 
     assert!(existent_key.is_some());

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -117,7 +117,7 @@ pub fn seed_data() -> (Vec<MonitorData>, Vec<JobData>, Vec<ApiKeyData>) {
             ApiKeyData {
                 api_key_id: gen_uuid("bfab6d41-8b00-49ef-86df-f562b701ee4f"),
                 tenant: "foo".to_owned(),
-                key: "foo-key".to_string(),
+                key: "104e4587f5340bd9264ea0fee2075627c74420bd5c48aa9e8a463f03a2675020".to_string(),
                 last_used: Some(gen_datetime("2024-05-01T00:00:00.000")),
                 last_used_monitor_id: Some(gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36")),
                 last_used_monitor_name: Some("db-backup.py".to_string()),
@@ -125,7 +125,7 @@ pub fn seed_data() -> (Vec<MonitorData>, Vec<JobData>, Vec<ApiKeyData>) {
             ApiKeyData {
                 api_key_id: gen_uuid("029d7c3b-00b5-4bb3-8e95-56d3f933e6a4"),
                 tenant: "foo".to_owned(),
-                key: "bar-key".to_string(),
+                key: "a3dd31a59c493fcbb87c1b7acfa1770740de6a712e11337648f42d64420ff4bc".to_string(),
                 last_used: None,
                 last_used_monitor_id: None,
                 last_used_monitor_name: None,
@@ -133,7 +133,7 @@ pub fn seed_data() -> (Vec<MonitorData>, Vec<JobData>, Vec<ApiKeyData>) {
             ApiKeyData {
                 api_key_id: gen_uuid("ea137deb-dfe0-4dca-bfd4-019492a522b1"),
                 tenant: "bar".to_owned(),
-                key: "baz-key".to_string(),
+                key: "03c8d72da14dd44e7a1310dc396a4c36d9bb4cd941500b599285a55803070bb8".to_string(),
                 last_used: None,
                 last_used_monitor_id: None,
                 last_used_monitor_name: None,


### PR DESCRIPTION
A relatively simple change to move from storing raw API keys to SHA256 hashes of them.

Related to #22 