### PR TITLE
Feat/alert configs and monitors

### DIFF
--- a/api/src/domain/models/alert_config.rs
+++ b/api/src/domain/models/alert_config.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 use uuid::Uuid;
 
+use crate::domain::models::monitor::Monitor;
+use crate::errors::Error;
+
 /// A domain model representing user configuration for alerts.
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct AlertConfig {
@@ -19,6 +22,8 @@ pub struct AlertConfig {
     /// The type of alert.
     #[serde(rename = "type")]
     pub type_: AlertType,
+    /// A list of IDs for Monitors that this alert configuration is associated with.
+    pub monitor_ids: Vec<Uuid>,
 }
 
 /// The different types of alerts that can be configured.
@@ -57,13 +62,49 @@ impl AlertConfig {
             on_late,
             on_error,
             type_: AlertType::Slack(SlackAlertConfig { channel, token }),
+            monitor_ids: Vec::new(),
         }
+    }
+
+    /// Associate a monitor with this alert configuration.
+    pub fn associate_monitor(&mut self, monitor: &Monitor) -> Result<(), Error> {
+        // Protect against duplicates.
+        if self.is_associated_with_monitor(monitor) {
+            return Err(Error::AlertConfigurationError(format!(
+                "Monitor('{}') is already associated with Alert Configuration('{}')",
+                monitor.monitor_id, self.alert_config_id
+            )));
+        }
+        self.monitor_ids.push(monitor.monitor_id);
+        Ok(())
+    }
+
+    /// Disassociate a monitor with this alert configuration.
+    pub fn disassociate_monitor(&mut self, monitor: &Monitor) -> Result<(), Error> {
+        // Ensure the monitor is currently associated with the alert configuration before removing
+        // it.
+        if !self.is_associated_with_monitor(monitor) {
+            return Err(Error::AlertConfigurationError(format!(
+                "Monitor('{}') is not associated with Alert Configuration('{}')",
+                monitor.monitor_id, self.alert_config_id
+            )));
+        }
+        self.monitor_ids.retain(|&id| id != monitor.monitor_id);
+        Ok(())
+    }
+
+    /// Check if the alert configuration is associated with a monitor.
+    pub fn is_associated_with_monitor(&self, monitor: &Monitor) -> bool {
+        self.monitor_ids.contains(&monitor.monitor_id)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
     use serde_json::json;
+
+    use test_utils::gen_uuid;
 
     use super::*;
 
@@ -93,6 +134,7 @@ mod tests {
                 token: "test-token".to_string(),
             })
         );
+        assert!(alert_config.monitor_ids.is_empty());
     }
 
     #[test]
@@ -122,8 +164,109 @@ mod tests {
                         "channel": "test-channel",
                         "token": "test-token"
                     }
-                }
+                },
+                "monitor_ids": []
             })
+        );
+    }
+
+    #[test]
+    fn test_associating_and_disassociating_monitors() {
+        let mut alert_config = AlertConfig::new_slack_config(
+            "test-name".to_string(),
+            "test-tenant".to_string(),
+            true,
+            true,
+            true,
+            "test-channel".to_string(),
+            "test-token".to_string(),
+        );
+        let monitor = Monitor::new("test-tenant".to_string(), "test-name".to_string(), 200, 100);
+
+        // Sanity check to make sure we start from a clean slate.
+        assert_eq!(alert_config.monitor_ids, vec![]);
+        assert!(!alert_config.is_associated_with_monitor(&monitor));
+
+        alert_config.associate_monitor(&monitor).unwrap();
+
+        assert_eq!(alert_config.monitor_ids, vec![monitor.monitor_id]);
+        assert!(alert_config.is_associated_with_monitor(&monitor));
+
+        alert_config.disassociate_monitor(&monitor).unwrap();
+
+        assert_eq!(alert_config.monitor_ids, vec![]);
+        assert!(!alert_config.is_associated_with_monitor(&monitor));
+    }
+
+    #[test]
+    fn test_associating_duplicate_monitors() {
+        let monitor = Monitor {
+            monitor_id: gen_uuid("ba0cd705-4a5b-4635-9def-611b1143e4aa"),
+            name: "test-name".to_string(),
+            tenant: "test-tenant".to_string(),
+            expected_duration: 200,
+            grace_duration: 100,
+            jobs: vec![],
+        };
+        let mut alert_config = AlertConfig {
+            alert_config_id: gen_uuid("bd594a8d-5449-43b8-9a1d-c650a8b9a0e6"),
+            name: "test-name".to_string(),
+            tenant: "test-tenant".to_string(),
+            active: true,
+            on_late: true,
+            on_error: true,
+            type_: AlertType::Slack(SlackAlertConfig {
+                channel: "test-channel".to_string(),
+                token: "test-token".to_string(),
+            }),
+            monitor_ids: vec![gen_uuid("ba0cd705-4a5b-4635-9def-611b1143e4aa")],
+        };
+
+        let result = alert_config.associate_monitor(&monitor);
+
+        assert_eq!(
+            result,
+            Err(Error::AlertConfigurationError(
+                "Monitor('ba0cd705-4a5b-4635-9def-611b1143e4aa') is already associated with Alert \
+                Configuration('bd594a8d-5449-43b8-9a1d-c650a8b9a0e6')"
+                    .to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_disassociating_non_associated_monitor() {
+        let monitor = Monitor {
+            monitor_id: gen_uuid("ba0cd705-4a5b-4635-9def-611b1143e4aa"),
+            name: "test-name".to_string(),
+            tenant: "test-tenant".to_string(),
+            expected_duration: 200,
+            grace_duration: 100,
+            jobs: vec![],
+        };
+        let mut alert_config = AlertConfig {
+            alert_config_id: gen_uuid("bd594a8d-5449-43b8-9a1d-c650a8b9a0e6"),
+            name: "test-name".to_string(),
+            tenant: "test-tenant".to_string(),
+            active: true,
+            on_late: true,
+            on_error: true,
+            type_: AlertType::Slack(SlackAlertConfig {
+                channel: "test-channel".to_string(),
+                token: "test-token".to_string(),
+            }),
+            monitor_ids: vec![],
+        };
+
+        let result = alert_config.disassociate_monitor(&monitor);
+
+        assert_eq!(
+            result,
+            Err(Error::AlertConfigurationError(
+                "Monitor('ba0cd705-4a5b-4635-9def-611b1143e4aa') is not associated with Alert \
+                Configuration('bd594a8d-5449-43b8-9a1d-c650a8b9a0e6')"
+                    .to_string()
+            ))
         );
     }
 }

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -10,6 +10,7 @@ pub enum Error {
     ApiKeyNotFound(Uuid),
     JobNotFound(Uuid, Uuid),
     JobAlreadyFinished(Uuid),
+    AlertConfigurationError(String),
     InvalidMonitor(String),
     InvalidJob(String),
     InvalidAlertConfig(String),
@@ -35,6 +36,9 @@ impl Display for Error {
             }
             Self::JobAlreadyFinished(job_id) => {
                 write!(f, "Job('{job_id}') is already finished")
+            }
+            Self::AlertConfigurationError(reason) => {
+                write!(f, "Failed to configure alert: {reason}")
             }
             Self::InvalidMonitor(reason) => write!(f, "Invalid Monitor: {reason}"),
             Self::InvalidJob(reason) => write!(f, "Invalid Job: {reason}"),

--- a/api/src/infrastructure/models/alert_config.rs
+++ b/api/src/infrastructure/models/alert_config.rs
@@ -7,6 +7,7 @@ use crate::infrastructure::db_schema::{alert_config, monitor_alert_config, slack
 
 // Only used for reading data.
 #[derive(Clone, Queryable)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct AlertConfigData {
     pub alert_config_id: Uuid,
     pub name: String,
@@ -23,6 +24,7 @@ pub struct AlertConfigData {
 #[derive(Identifiable, Insertable, Queryable)]
 #[diesel(table_name = monitor_alert_config)]
 #[diesel(primary_key(alert_config_id, monitor_id))]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct MonitorAlertConfigData {
     pub alert_config_id: Uuid,
     pub monitor_id: Uuid,
@@ -32,6 +34,7 @@ pub struct MonitorAlertConfigData {
 #[derive(Identifiable, Insertable, AsChangeset)]
 #[diesel(table_name = alert_config)]
 #[diesel(primary_key(alert_config_id))]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct NewAlertConfigData {
     pub alert_config_id: Uuid,
     pub name: String,
@@ -46,6 +49,7 @@ pub struct NewAlertConfigData {
 #[derive(Identifiable, Insertable, AsChangeset)]
 #[diesel(table_name = slack_alert_config)]
 #[diesel(primary_key(alert_config_id))]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct NewSlackAlertConfigData {
     pub alert_config_id: Uuid,
     pub slack_channel: String,

--- a/api/src/infrastructure/models/alert_config.rs
+++ b/api/src/infrastructure/models/alert_config.rs
@@ -72,6 +72,7 @@ impl AlertConfigData {
             on_late: self.on_late,
             on_error: self.on_error,
             type_: match self.type_.as_str() {
+                // TODO: This constant should be in the domain layer.
                 "slack" => {
                     if let (Some(channel), Some(token)) =
                         (&self.slack_channel, &self.slack_bot_oauth_token)

--- a/api/src/infrastructure/models/alert_config.rs
+++ b/api/src/infrastructure/models/alert_config.rs
@@ -66,6 +66,8 @@ impl AlertConfigData {
                 }
                 _ => return Err(Error::InvalidAlertConfig("Unknown alert type".to_owned())),
             },
+            // TODO: Implement the rest of the conversion
+            monitor_ids: Vec::new(),
         })
     }
 }
@@ -200,6 +202,7 @@ mod tests {
                 channel: "test-channel".to_owned(),
                 token: "test-token".to_owned(),
             }),
+            monitor_ids: Vec::new(),
         };
 
         let (alert_config_data, slack_data) = NewAlertConfigData::from_model(&alert_config);

--- a/api/src/infrastructure/models/alert_config.rs
+++ b/api/src/infrastructure/models/alert_config.rs
@@ -6,7 +6,9 @@ use crate::errors::Error;
 use crate::infrastructure::db_schema::{alert_config, monitor_alert_config, slack_alert_config};
 
 // Only used for reading data.
-#[derive(Clone, Queryable)]
+#[derive(Clone, Identifiable, Queryable)]
+#[diesel(table_name = alert_config)]
+#[diesel(primary_key(alert_config_id))]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct AlertConfigData {
     pub alert_config_id: Uuid,
@@ -21,7 +23,8 @@ pub struct AlertConfigData {
 }
 
 // Used for reading and writing data.
-#[derive(Identifiable, Insertable, Queryable)]
+#[derive(Associations, Identifiable, Insertable, Queryable, Selectable)]
+#[diesel(belongs_to(AlertConfigData, foreign_key = alert_config_id))]
 #[diesel(table_name = monitor_alert_config)]
 #[diesel(primary_key(alert_config_id, monitor_id))]
 #[diesel(check_for_backend(diesel::pg::Pg))]

--- a/api/src/infrastructure/repositories/alert_config_repo.rs
+++ b/api/src/infrastructure/repositories/alert_config_repo.rs
@@ -11,8 +11,7 @@ use crate::domain::models::alert_config::AlertConfig;
 use crate::errors::Error;
 use crate::infrastructure::database::{get_connection, DbPool};
 use crate::infrastructure::db_schema::{alert_config, slack_alert_config};
-use crate::infrastructure::models::alert_config::AlertConfigData;
-use crate::infrastructure::models::alert_config::NewAlertConfigData;
+use crate::infrastructure::models::alert_config::{AlertConfigData, NewAlertConfigData};
 use crate::infrastructure::repositories::Repository;
 
 macro_rules! build_polymorphic_query {
@@ -51,7 +50,7 @@ impl<'a> AlertConfigRepository<'a> {
     }
 
     fn db_to_model(&mut self, alert_config_data: &AlertConfigData) -> Result<AlertConfig, Error> {
-        let alert_config = alert_config_data.to_model()?;
+        let alert_config = alert_config_data.to_model(&[])?;
         self.data
             .insert(alert_config.alert_config_id, alert_config.clone());
         Ok(alert_config)
@@ -111,7 +110,7 @@ impl<'a> Repository<AlertConfig> for AlertConfigRepository<'a> {
     }
 
     async fn save(&mut self, alert_config: &AlertConfig) -> Result<(), Error> {
-        let (alert_config_data, slack_alert_config_data) =
+        let (alert_config_data, _, slack_alert_config_data) =
             NewAlertConfigData::from_model(alert_config);
 
         // We can do this now as we only support Slack, but when we add more integrations we will

--- a/api/tests/alert_config_repo_test.rs
+++ b/api/tests/alert_config_repo_test.rs
@@ -82,6 +82,10 @@ async fn test_get(#[future] infrastructure: Infrastructure) {
 
     let alert_config = should_be_some.unwrap();
     assert_eq!(alert_config.name, "Test Slack alert (for lates)");
+    assert_eq!(
+        alert_config.monitor_ids,
+        vec![gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36")]
+    )
 }
 
 #[rstest]
@@ -90,7 +94,7 @@ async fn test_save_with_new(#[future] infrastructure: Infrastructure) {
     let infra = infrastructure.await;
     let mut repo = AlertConfigRepository::new(&infra.pool);
 
-    let new_alert_config = AlertConfig::new_slack_config(
+    let mut new_alert_config = AlertConfig::new_slack_config(
         "New config".to_string(),
         "foo".to_string(),
         false,
@@ -99,6 +103,10 @@ async fn test_save_with_new(#[future] infrastructure: Infrastructure) {
         "#new-channel".to_string(),
         "new-test-token".to_string(),
     );
+    new_alert_config.monitor_ids = vec![
+        gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"),
+        gen_uuid("f0b291fe-bd41-4787-bc2d-1329903f7a6a"),
+    ];
 
     repo.save(&new_alert_config).await.unwrap();
     assert_eq!(repo.all("foo").await.unwrap().len(), 4);
@@ -117,6 +125,10 @@ async fn test_save_with_new(#[future] infrastructure: Infrastructure) {
     assert_eq!(new_alert_config.on_late, read_new_alert_config.on_late);
     assert_eq!(new_alert_config.on_error, read_new_alert_config.on_error);
     assert_eq!(new_alert_config.type_, read_new_alert_config.type_);
+    assert_eq!(
+        new_alert_config.monitor_ids,
+        read_new_alert_config.monitor_ids
+    );
 }
 
 #[rstest]
@@ -134,6 +146,10 @@ async fn test_save_with_existing(#[future] infrastructure: Infrastructure) {
     alert_config.active = false;
     alert_config.on_late = false;
     alert_config.on_error = false;
+    alert_config.monitor_ids = vec![
+        gen_uuid("f0b291fe-bd41-4787-bc2d-1329903f7a6a"),
+        gen_uuid("cc6cf74e-b25d-4c8c-94a6-914e3f139c14"),
+    ];
 
     repo.save(&alert_config).await.unwrap();
     assert_eq!(repo.all("foo").await.unwrap().len(), 3);
@@ -149,6 +165,7 @@ async fn test_save_with_existing(#[future] infrastructure: Infrastructure) {
     assert_eq!(alert_config.on_late, read_alert_config.on_late);
     assert_eq!(alert_config.on_error, read_alert_config.on_error);
     assert_eq!(alert_config.type_, read_alert_config.type_);
+    assert_eq!(alert_config.monitor_ids, read_alert_config.monitor_ids);
 }
 
 #[rstest]

--- a/api/tests/alert_config_repo_test.rs
+++ b/api/tests/alert_config_repo_test.rs
@@ -80,8 +80,8 @@ async fn test_get(#[future] infrastructure: Infrastructure) {
     assert!(wrong_tenant.is_none());
     assert!(should_be_some.is_some());
 
-    let monitor = should_be_some.unwrap();
-    assert_eq!(monitor.name, "Test Slack alert (for lates)");
+    let alert_config = should_be_some.unwrap();
+    assert_eq!(alert_config.name, "Test Slack alert (for lates)");
 }
 
 #[rstest]
@@ -194,13 +194,13 @@ async fn test_loading_invalid_config() {
     )
     .await;
 
-    // Attempt to retrieve that monitor.
+    // Attempt to retrieve that alert config.
     let mut repo = AlertConfigRepository::new(&infra.pool);
     let alert_config_result = repo
         .get(gen_uuid("027820c0-ab21-47cd-bff0-bc298b3e6646"), "foo")
         .await;
 
-    // Ensure that the monitor is not returned.
+    // Ensure that the alert config is not returned.
     assert_eq!(
         alert_config_result,
         Err(Error::InvalidAlertConfig(

--- a/api/tests/alert_config_repo_test.rs
+++ b/api/tests/alert_config_repo_test.rs
@@ -189,6 +189,7 @@ async fn test_loading_invalid_config() {
                 on_error: false,
             }],
             vec![],
+            vec![],
         ),
     )
     .await;

--- a/api/tests/common/infra.rs
+++ b/api/tests/common/infra.rs
@@ -4,7 +4,7 @@ use wiremock::MockServer;
 
 use cron_mon_api::infrastructure::database::{run_migrations, DbPool};
 use cron_mon_api::infrastructure::models::{
-    alert_config::{NewAlertConfigData, NewSlackAlertConfigData},
+    alert_config::{MonitorAlertConfigData, NewAlertConfigData, NewSlackAlertConfigData},
     api_key::ApiKeyData,
     job::JobData,
     monitor::MonitorData,
@@ -45,7 +45,11 @@ impl Infrastructure {
         monitor_seeds: Vec<MonitorData>,
         job_seeds: Vec<JobData>,
         api_key_seeds: Vec<ApiKeyData>,
-        alert_config_seeds: (Vec<NewAlertConfigData>, Vec<NewSlackAlertConfigData>),
+        alert_config_seeds: (
+            Vec<NewAlertConfigData>,
+            Vec<NewSlackAlertConfigData>,
+            Vec<MonitorAlertConfigData>,
+        ),
     ) -> Self {
         Self::new(monitor_seeds, job_seeds, api_key_seeds, alert_config_seeds).await
     }
@@ -54,7 +58,11 @@ impl Infrastructure {
         monitor_seeds: Vec<MonitorData>,
         job_seeds: Vec<JobData>,
         api_key_seeds: Vec<ApiKeyData>,
-        alert_config_seeds: (Vec<NewAlertConfigData>, Vec<NewSlackAlertConfigData>),
+        alert_config_seeds: (
+            Vec<NewAlertConfigData>,
+            Vec<NewSlackAlertConfigData>,
+            Vec<MonitorAlertConfigData>,
+        ),
     ) -> Self {
         let container = postgres_container().await;
 

--- a/api/tests/common/seeds.rs
+++ b/api/tests/common/seeds.rs
@@ -1,5 +1,5 @@
 use cron_mon_api::infrastructure::models::{
-    alert_config::{NewAlertConfigData, NewSlackAlertConfigData},
+    alert_config::{MonitorAlertConfigData, NewAlertConfigData, NewSlackAlertConfigData},
     api_key::ApiKeyData,
     job::JobData,
     monitor::MonitorData,
@@ -137,7 +137,11 @@ pub fn api_key_seeds() -> Vec<ApiKeyData> {
     ]
 }
 
-pub fn alert_config_seeds() -> (Vec<NewAlertConfigData>, Vec<NewSlackAlertConfigData>) {
+pub fn alert_config_seeds() -> (
+    Vec<NewAlertConfigData>,
+    Vec<NewSlackAlertConfigData>,
+    Vec<MonitorAlertConfigData>,
+) {
     (
         vec![
             NewAlertConfigData {
@@ -183,6 +187,28 @@ pub fn alert_config_seeds() -> (Vec<NewAlertConfigData>, Vec<NewSlackAlertConfig
                 alert_config_id: gen_uuid("8d307d12-4696-4801-bfb6-628f8f640864"),
                 slack_channel: "#test-channel".to_owned(),
                 slack_bot_oauth_token: "test-token".to_owned(),
+            },
+        ],
+        vec![
+            MonitorAlertConfigData {
+                monitor_id: gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"),
+                alert_config_id: gen_uuid("fadd7266-648b-4102-8f85-c768655f4297"),
+            },
+            MonitorAlertConfigData {
+                monitor_id: gen_uuid("f0b291fe-bd41-4787-bc2d-1329903f7a6a"),
+                alert_config_id: gen_uuid("3ba21f52-32c9-41dc-924d-d18d4fc0e81c"),
+            },
+            MonitorAlertConfigData {
+                monitor_id: gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"),
+                alert_config_id: gen_uuid("3ba21f52-32c9-41dc-924d-d18d4fc0e81c"),
+            },
+            MonitorAlertConfigData {
+                monitor_id: gen_uuid("cc6cf74e-b25d-4c8c-94a6-914e3f139c14"),
+                alert_config_id: gen_uuid("3ba21f52-32c9-41dc-924d-d18d4fc0e81c"),
+            },
+            MonitorAlertConfigData {
+                monitor_id: gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"),
+                alert_config_id: gen_uuid("8d307d12-4696-4801-bfb6-628f8f640864"),
             },
         ],
     )

--- a/api/tests/monitor_repo_test.rs
+++ b/api/tests/monitor_repo_test.rs
@@ -163,7 +163,7 @@ async fn test_loading_invalid_job() {
             error_alert_sent: false,
         }],
         vec![],
-        (vec![], vec![]),
+        (vec![], vec![], vec![]),
     )
     .await;
 


### PR DESCRIPTION
Related to #24.

Add a list of monitor IDs an `AlertConfig` is for, with functionality on the model itself to support this, and most importantly the required changes to the `AlertConfigRepository` to facilitate this.