### PR TITLE
Feat/monitor names in alert configs

### DIFF
--- a/api/src/infrastructure/db_schema.rs
+++ b/api/src/infrastructure/db_schema.rs
@@ -62,6 +62,7 @@ diesel::table! {
     monitor_alert_config (alert_config_id, monitor_id) {
         alert_config_id -> Uuid,
         monitor_id -> Uuid,
+        monitor_name -> Varchar,
     }
 }
 

--- a/api/src/infrastructure/migrations/2024-12-13-222551_add-name-to-monitor-alert-config/down.sql
+++ b/api/src/infrastructure/migrations/2024-12-13-222551_add-name-to-monitor-alert-config/down.sql
@@ -1,0 +1,5 @@
+-- Drop trigger and function
+DROP TRIGGER IF EXISTS monitor_name_update ON monitor;
+DROP FUNCTION IF EXISTS update_monitor_alert_config_monitor_name;
+
+ALTER TABLE monitor_alert_config DROP monitor_name;

--- a/api/src/infrastructure/migrations/2024-12-13-222551_add-name-to-monitor-alert-config/up.sql
+++ b/api/src/infrastructure/migrations/2024-12-13-222551_add-name-to-monitor-alert-config/up.sql
@@ -1,0 +1,30 @@
+-- Add name to monitor_alert_config, nullable for now.
+ALTER TABLE monitor_alert_config
+    ADD monitor_name VARCHAR NULL;
+
+-- Set the names to what they are currently, then make the column non-nullable.
+UPDATE monitor_alert_config
+    SET monitor_name = monitor.name
+FROM monitor
+WHERE monitor_alert_config.monitor_id = monitor.monitor_id;
+
+ALTER TABLE monitor_alert_config
+    ALTER COLUMN monitor_name SET NOT NULL;
+
+-- Create a trigger function for updating the monitor name in monitor_alert_config.
+CREATE OR REPLACE FUNCTION update_monitor_alert_config_monitor_name()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE monitor_alert_config
+    SET monitor_name = NEW.name
+    WHERE monitor_id = NEW.monitor_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply the trigger to the monitor table so that when name changes, the changes are
+-- reflected in the monitor_alert_config table.
+CREATE TRIGGER monitor_name_update
+AFTER UPDATE OF name ON monitor
+FOR EACH ROW
+EXECUTE FUNCTION update_monitor_alert_config_monitor_name();

--- a/api/src/infrastructure/models/alert_config.rs
+++ b/api/src/infrastructure/models/alert_config.rs
@@ -33,6 +33,9 @@ pub struct AlertConfigData {
 pub struct MonitorAlertConfigData {
     pub alert_config_id: Uuid,
     pub monitor_id: Uuid,
+    // Note that this column will be kept up to date with the `name` of the corresponding `monitor`
+    // record by the `monitor_name_update` trigger, added in the
+    // `2024-12-13-222551_add-name-to-monitor-alert-config` migration.
     pub monitor_name: String,
 }
 

--- a/api/src/infrastructure/seeding/seeds.sql
+++ b/api/src/infrastructure/seeding/seeds.sql
@@ -264,7 +264,7 @@ VALUES
 
 -- Monitor alert configs.
 INSERT INTO monitor_alert_config
-    (alert_config_id, monitor_id)
+    (alert_config_id, monitor_id, monitor_name)
 VALUES
-    ('f1b1b1b1-1b1b-1b1b-1b1b-1b1b1b1b1b1b', 'c1bf0515-df39-448b-aa95-686360a33b36'),
-    ('f1b1b1b1-1b1b-1b1b-1b1b-1b1b1b1b1b1b', 'f0b291fe-bd41-4787-bc2d-1329903f7a6a');
+    ('f1b1b1b1-1b1b-1b1b-1b1b-1b1b1b1b1b1b', 'c1bf0515-df39-448b-aa95-686360a33b36', 'db-backup.py'),
+    ('f1b1b1b1-1b1b-1b1b-1b1b-1b1b1b1b1b1b', 'f0b291fe-bd41-4787-bc2d-1329903f7a6a', 'generate-orders.sh');

--- a/api/tests/common/seeds.rs
+++ b/api/tests/common/seeds.rs
@@ -193,22 +193,27 @@ pub fn alert_config_seeds() -> (
             MonitorAlertConfigData {
                 monitor_id: gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"),
                 alert_config_id: gen_uuid("fadd7266-648b-4102-8f85-c768655f4297"),
+                monitor_name: "db-backup.py".to_string(),
             },
             MonitorAlertConfigData {
                 monitor_id: gen_uuid("f0b291fe-bd41-4787-bc2d-1329903f7a6a"),
                 alert_config_id: gen_uuid("3ba21f52-32c9-41dc-924d-d18d4fc0e81c"),
+                monitor_name: "generate-orders.sh".to_string(),
             },
             MonitorAlertConfigData {
                 monitor_id: gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"),
                 alert_config_id: gen_uuid("3ba21f52-32c9-41dc-924d-d18d4fc0e81c"),
+                monitor_name: "db-backup.py".to_string(),
             },
             MonitorAlertConfigData {
                 monitor_id: gen_uuid("cc6cf74e-b25d-4c8c-94a6-914e3f139c14"),
                 alert_config_id: gen_uuid("3ba21f52-32c9-41dc-924d-d18d4fc0e81c"),
+                monitor_name: "data-snapshot.py".to_string(),
             },
             MonitorAlertConfigData {
                 monitor_id: gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"),
                 alert_config_id: gen_uuid("8d307d12-4696-4801-bfb6-628f8f640864"),
+                monitor_name: "db-backup.py".to_string(),
             },
         ],
     )


### PR DESCRIPTION
Related to #24 

Add Monitor names to `AlertConfig` domain model via the `monitor_alert_config` association table and a trigger to reflect changes on `monitor.name` to `monitor_alert_config.monitor_name`.