### PR TITLE
Feat/optional tenant 4 get by monitors

### DIFF
--- a/api/src/application/routes/jobs.rs
+++ b/api/src/application/routes/jobs.rs
@@ -34,7 +34,7 @@ pub async fn get_job(
 }
 
 #[rocket::post("/monitors/<monitor_id>/jobs/start")]
-pub async fn start_job<'r>(
+pub async fn start_job(
     pool: &State<DbPool>,
     key: ApiKey,
     monitor_id: Uuid,

--- a/api/src/application/services/alert_configs/fetch_alert_configs.rs
+++ b/api/src/application/services/alert_configs/fetch_alert_configs.rs
@@ -31,7 +31,7 @@ impl<Monitors: Repository<Monitor>, AlertConfigs: GetByMonitors>
         }
 
         self.alert_config_repo
-            .get_by_monitors(&[monitor_id], tenant)
+            .get_by_monitors(&[monitor_id], Some(tenant))
             .await
     }
 }
@@ -76,7 +76,7 @@ mod tests {
             .once()
             .withf(move |monitor_ids, tenant| {
                 monitor_ids == vec![gen_uuid("6fad996a-df7d-42a3-aaad-a5e7d101ac54")]
-                    && tenant == "tenant"
+                    && *tenant == Some("tenant")
             })
             .returning(move |_, _| {
                 Ok(vec![

--- a/api/src/infrastructure/repositories/alert_config/mod.rs
+++ b/api/src/infrastructure/repositories/alert_config/mod.rs
@@ -14,9 +14,9 @@ pub use alert_config_repo::AlertConfigRepository;
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait GetByMonitors {
-    async fn get_by_monitors(
+    async fn get_by_monitors<'a>(
         &mut self,
         monitor_ids: &[Uuid],
-        tenant: &str,
+        tenant: Option<&'a str>,
     ) -> Result<Vec<AlertConfig>, Error>;
 }

--- a/api/tests/common/seeds.rs
+++ b/api/tests/common/seeds.rs
@@ -171,6 +171,15 @@ pub fn alert_config_seeds() -> (
                 on_late: true,
                 on_error: true,
             },
+            NewAlertConfigData {
+                alert_config_id: gen_uuid("76725038-86a0-46d6-b97a-05735f71cb4f"),
+                name: "Test Slack alert".to_owned(),
+                tenant: "bar".to_owned(),
+                type_: "slack".to_owned(),
+                active: true,
+                on_late: true,
+                on_error: true,
+            },
         ],
         vec![
             NewSlackAlertConfigData {


### PR DESCRIPTION
Make `tenant` optional in `GetByMonitors`, as while we need it for the `GET /api/v1/alert-configs` endpoint, when processing late and errored jobs we won't have a tenant in the current context.

Related to #24