### PR TITLE
Feat/test alerts api

### DIFF
--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -608,7 +608,7 @@ paths:
     post:
       tags:
         - Alert Configurations
-      summary: Createm a new alert configuration
+      summary: Create a new alert configuration
       security:
         - bearerAuth: []
       requestBody:

--- a/api/src/application/routes/alert_config.rs
+++ b/api/src/application/routes/alert_config.rs
@@ -1,4 +1,5 @@
 use rocket;
+use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::State;
 use serde_json::{json, Value};
@@ -7,7 +8,8 @@ use uuid::Uuid;
 use crate::application::services::alert_configs::AlertConfigData;
 use crate::application::services::{
     get_create_alert_config_service, get_delete_alert_config_service,
-    get_fetch_alert_configs_service, get_update_alert_config_service,
+    get_fetch_alert_configs_service, get_test_alert_config_service,
+    get_update_alert_config_service,
 };
 use crate::errors::Error;
 use crate::infrastructure::auth::Jwt;
@@ -98,6 +100,21 @@ pub async fn delete_alert_config(
     delete_alert_config
         .delete_by_id(alert_config_id, &jwt.tenant)
         .await
+}
+
+#[rocket::post("/alert-configs/<alert_config_id>/test")]
+pub async fn test_alert_config(
+    pool: &State<DbPool>,
+    jwt: Jwt,
+    alert_config_id: Uuid,
+) -> Result<Status, Error> {
+    let mut test_alert_config = get_test_alert_config_service(pool);
+
+    test_alert_config
+        .for_alert_config(alert_config_id, &jwt.tenant, &jwt.name)
+        .await?;
+
+    Ok(Status::Created)
 }
 
 #[rocket::get("/monitors/<monitor_id>/alert-configs")]

--- a/api/src/application/services/alert_configs/mod.rs
+++ b/api/src/application/services/alert_configs/mod.rs
@@ -1,6 +1,7 @@
 pub mod create_alert_config;
 pub mod delete_alert_config;
 pub mod fetch_alert_configs;
+pub mod test_alert_config;
 pub mod update_alert_config;
 
 use serde::Deserialize;
@@ -8,6 +9,7 @@ use serde::Deserialize;
 pub use create_alert_config::CreateAlertConfigService;
 pub use delete_alert_config::DeleteAlertConfigService;
 pub use fetch_alert_configs::FetchAlertConfigs;
+pub use test_alert_config::TestAlertConfigService;
 pub use update_alert_config::UpdateAlertConfigService;
 
 #[derive(Deserialize)]

--- a/api/src/application/services/alert_configs/test_alert_config.rs
+++ b/api/src/application/services/alert_configs/test_alert_config.rs
@@ -1,0 +1,312 @@
+use tracing::info;
+use uuid::Uuid;
+
+use crate::domain::models::AlertConfig;
+use crate::domain::services::get_notifier::GetNotifier;
+use crate::errors::Error;
+use crate::infrastructure::repositories::Repository;
+
+/// A service that retrieves a notifier for a given alert configuration.
+pub struct TestAlertConfigService<
+    AlertConfigRepo: Repository<AlertConfig>,
+    NotifierFactory: GetNotifier,
+> {
+    alert_config_repo: AlertConfigRepo,
+    notifier_factory: NotifierFactory,
+}
+
+impl<AlertConfigRepo: Repository<AlertConfig>, NotifierFactory: GetNotifier>
+    TestAlertConfigService<AlertConfigRepo, NotifierFactory>
+{
+    /// Create a new instance of the service.
+    pub fn new(alert_config_repo: AlertConfigRepo, notifier_factory: NotifierFactory) -> Self {
+        Self {
+            alert_config_repo,
+            notifier_factory,
+        }
+    }
+
+    pub async fn for_alert_config(
+        &mut self,
+        alert_config_id: Uuid,
+        tenant: &str,
+        user: &str,
+    ) -> Result<(), Error> {
+        info!(alert_config_id = ?alert_config_id, user = user, "Testing alert configuration...");
+
+        // Retrieve the AlertConfig.
+        let alert_config = self
+            .alert_config_repo
+            .get(alert_config_id, tenant)
+            .await?
+            .ok_or(Error::AlertConfigNotFound(alert_config_id))?;
+
+        let mut notifier = self.notifier_factory.get_notifier(&alert_config);
+        notifier.test_notification(&alert_config, user).await?;
+
+        info!(alert_config_id = ?alert_config_id, user = user, "Tested '{}' alert configuration", &alert_config.name);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mockall::predicate::*;
+    use tracing::Level;
+    use tracing_test::traced_test;
+
+    use test_utils::gen_uuid;
+    use test_utils::logging::TracingLog;
+
+    use crate::domain::models::{AlertConfig, AlertType, SlackAlertConfig};
+    use crate::domain::services::get_notifier::MockGetNotifier;
+    use crate::infrastructure::notify::MockNotifier;
+    use crate::infrastructure::repositories::MockRepository;
+
+    use super::*;
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_test_alert_config_service() {
+        let alert_config_id = gen_uuid("3691d251-0b49-4f30-ba83-9c489940c675");
+
+        let mut mock_alert_config_repo = MockRepository::new();
+        mock_alert_config_repo
+            .expect_get()
+            .once()
+            .with(eq(alert_config_id), eq("foo-tenant"))
+            .returning(move |_, _| {
+                Ok(Some(AlertConfig {
+                    alert_config_id,
+                    tenant: "foo-tenant".to_owned(),
+                    name: "Test alert config".to_owned(),
+                    active: true,
+                    on_late: true,
+                    on_error: true,
+                    monitors: vec![],
+                    type_: AlertType::Slack(SlackAlertConfig {
+                        token: "token".to_owned(),
+                        channel: "channel".to_owned(),
+                    }),
+                }))
+            });
+
+        let alert_config_predicate = move |alert_config: &AlertConfig| {
+            alert_config.alert_config_id == alert_config_id
+                && alert_config.tenant == "foo-tenant"
+                && matches!(alert_config.type_, AlertType::Slack(_))
+        };
+
+        let mut mock_notifier_factory = MockGetNotifier::new();
+        mock_notifier_factory
+            .expect_get_notifier()
+            .once()
+            .withf(alert_config_predicate)
+            .returning(move |_| {
+                let mut notifier = MockNotifier::new();
+                notifier
+                    .expect_test_notification()
+                    .once()
+                    .with(function(alert_config_predicate), eq("Joe Bloggs"))
+                    .returning(|_, _| Ok(()));
+                Box::new(notifier)
+            });
+
+        let mut service =
+            TestAlertConfigService::new(mock_alert_config_repo, mock_notifier_factory);
+        service
+            .for_alert_config(alert_config_id, "foo-tenant", "Joe Bloggs")
+            .await
+            .unwrap();
+
+        logs_assert(|logs| {
+            let logs = TracingLog::from_logs(logs);
+
+            assert_eq!(
+                logs.iter().map(|log| log.level).collect::<Vec<Level>>(),
+                vec![Level::INFO, Level::INFO]
+            );
+            assert_eq!(
+                logs.iter()
+                    .map(|log| log.body.clone())
+                    .collect::<Vec<String>>(),
+                [
+                    "Testing alert configuration... \
+                        alert_config_id=3691d251-0b49-4f30-ba83-9c489940c675 user=\"Joe Bloggs\"",
+                    "Tested 'Test alert config' alert configuration \
+                        alert_config_id=3691d251-0b49-4f30-ba83-9c489940c675 user=\"Joe Bloggs\""
+                ]
+            );
+
+            Ok(())
+        });
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_test_alert_config_service_repo_error() {
+        let alert_config_id = gen_uuid("3691d251-0b49-4f30-ba83-9c489940c675");
+
+        let mut mock_alert_config_repo = MockRepository::new();
+        mock_alert_config_repo
+            .expect_get()
+            .once()
+            .with(eq(alert_config_id), eq("foo-tenant"))
+            .returning(move |_, _| {
+                Err(Error::RepositoryError(
+                    "Failed to get alert config".to_owned(),
+                ))
+            });
+
+        let mut mock_notifier_factory = MockGetNotifier::new();
+        mock_notifier_factory.expect_get_notifier().never();
+
+        let mut service =
+            TestAlertConfigService::new(mock_alert_config_repo, mock_notifier_factory);
+        let result = service
+            .for_alert_config(alert_config_id, "foo-tenant", "Joe Bloggs")
+            .await;
+        assert_eq!(
+            result,
+            Err(Error::RepositoryError(
+                "Failed to get alert config".to_owned(),
+            )),
+        );
+
+        logs_assert(|logs| {
+            let logs = TracingLog::from_logs(logs);
+
+            assert_eq!(
+                logs.iter().map(|log| log.level).collect::<Vec<Level>>(),
+                vec![Level::INFO]
+            );
+            assert_eq!(
+                logs.iter()
+                    .map(|log| log.body.clone())
+                    .collect::<Vec<String>>(),
+                ["Testing alert configuration... \
+                        alert_config_id=3691d251-0b49-4f30-ba83-9c489940c675 user=\"Joe Bloggs\"",]
+            );
+
+            Ok(())
+        });
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_test_alert_config_service_alert_config_not_found() {
+        let alert_config_id = gen_uuid("3691d251-0b49-4f30-ba83-9c489940c675");
+
+        let mut mock_alert_config_repo = MockRepository::new();
+        mock_alert_config_repo
+            .expect_get()
+            .once()
+            .with(eq(alert_config_id), eq("foo-tenant"))
+            .returning(move |_, _| Ok(None));
+
+        let mut mock_notifier_factory = MockGetNotifier::new();
+        mock_notifier_factory.expect_get_notifier().never();
+
+        let mut service =
+            TestAlertConfigService::new(mock_alert_config_repo, mock_notifier_factory);
+        let result = service
+            .for_alert_config(alert_config_id, "foo-tenant", "Joe Bloggs")
+            .await;
+        assert_eq!(result, Err(Error::AlertConfigNotFound(alert_config_id)));
+
+        logs_assert(|logs| {
+            let logs = TracingLog::from_logs(logs);
+
+            assert_eq!(
+                logs.iter().map(|log| log.level).collect::<Vec<Level>>(),
+                vec![Level::INFO]
+            );
+            assert_eq!(
+                logs.iter()
+                    .map(|log| log.body.clone())
+                    .collect::<Vec<String>>(),
+                ["Testing alert configuration... \
+                        alert_config_id=3691d251-0b49-4f30-ba83-9c489940c675 user=\"Joe Bloggs\""]
+            );
+
+            Ok(())
+        });
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_test_alert_config_service_notify_error() {
+        let alert_config_id = gen_uuid("3691d251-0b49-4f30-ba83-9c489940c675");
+
+        let mut mock_alert_config_repo = MockRepository::new();
+        mock_alert_config_repo
+            .expect_get()
+            .once()
+            .with(eq(alert_config_id), eq("foo-tenant"))
+            .returning(move |_, _| {
+                Ok(Some(AlertConfig {
+                    alert_config_id,
+                    tenant: "foo-tenant".to_owned(),
+                    name: "Test alert config".to_owned(),
+                    active: true,
+                    on_late: true,
+                    on_error: true,
+                    monitors: vec![],
+                    type_: AlertType::Slack(SlackAlertConfig {
+                        token: "token".to_owned(),
+                        channel: "channel".to_owned(),
+                    }),
+                }))
+            });
+
+        let alert_config_predicate = move |alert_config: &AlertConfig| {
+            alert_config.alert_config_id == alert_config_id
+                && alert_config.tenant == "foo-tenant"
+                && matches!(alert_config.type_, AlertType::Slack(_))
+        };
+
+        let mut mock_notifier_factory = MockGetNotifier::new();
+        mock_notifier_factory
+            .expect_get_notifier()
+            .once()
+            .withf(alert_config_predicate)
+            .returning(move |_| {
+                let mut notifier = MockNotifier::new();
+                notifier
+                    .expect_test_notification()
+                    .once()
+                    .with(function(alert_config_predicate), eq("Joe Bloggs"))
+                    .returning(|_, _| Err(Error::NotifyError("Failed to notify".to_owned())));
+                Box::new(notifier)
+            });
+
+        let mut service =
+            TestAlertConfigService::new(mock_alert_config_repo, mock_notifier_factory);
+        let result = service
+            .for_alert_config(alert_config_id, "foo-tenant", "Joe Bloggs")
+            .await;
+        assert_eq!(
+            result,
+            Err(Error::NotifyError("Failed to notify".to_owned()))
+        );
+
+        logs_assert(|logs| {
+            let logs = TracingLog::from_logs(logs);
+
+            assert_eq!(
+                logs.iter().map(|log| log.level).collect::<Vec<Level>>(),
+                vec![Level::INFO]
+            );
+            assert_eq!(
+                logs.iter()
+                    .map(|log| log.body.clone())
+                    .collect::<Vec<String>>(),
+                ["Testing alert configuration... \
+                        alert_config_id=3691d251-0b49-4f30-ba83-9c489940c675 user=\"Joe Bloggs\""]
+            );
+
+            Ok(())
+        });
+    }
+}

--- a/api/src/application/services/mod.rs
+++ b/api/src/application/services/mod.rs
@@ -73,11 +73,11 @@ pub fn get_generate_key_service(pool: &DbPool) -> GenerateKeyService<ApiKeyRepos
 
 pub fn get_process_late_jobs_service(
     pool: &DbPool,
-) -> ProcessLateJobsService<MonitorRepository, AlertConfigRepository> {
+) -> ProcessLateJobsService<MonitorRepository, AlertConfigRepository, GetNotifierService> {
     ProcessLateJobsService::new(
         MonitorRepository::new(pool),
         AlertConfigRepository::new(pool),
-        Box::new(GetNotifierService::new()),
+        GetNotifierService::new(),
     )
 }
 

--- a/api/src/application/services/mod.rs
+++ b/api/src/application/services/mod.rs
@@ -11,7 +11,8 @@ use crate::infrastructure::repositories::api_key::ApiKeyRepository;
 use crate::infrastructure::repositories::monitor::MonitorRepository;
 
 use alert_configs::{
-    CreateAlertConfigService, DeleteAlertConfigService, FetchAlertConfigs, UpdateAlertConfigService,
+    CreateAlertConfigService, DeleteAlertConfigService, FetchAlertConfigs, TestAlertConfigService,
+    UpdateAlertConfigService,
 };
 use api_keys::{GenerateKeyService, RevokeKeyService};
 use monitors::{
@@ -89,6 +90,12 @@ pub fn get_start_job_service(
     pool: &DbPool,
 ) -> StartJobService<MonitorRepository, ApiKeyRepository> {
     StartJobService::new(MonitorRepository::new(pool), ApiKeyRepository::new(pool))
+}
+
+pub fn get_test_alert_config_service(
+    pool: &DbPool,
+) -> TestAlertConfigService<AlertConfigRepository, GetNotifierService> {
+    TestAlertConfigService::new(AlertConfigRepository::new(pool), GetNotifierService::new())
 }
 
 pub fn get_update_alert_config_service(

--- a/api/src/application/services/monitors/process_late_jobs.rs
+++ b/api/src/application/services/monitors/process_late_jobs.rs
@@ -124,8 +124,8 @@ mod tests {
 
     use crate::domain::models::{AlertType, AppliedMonitor, EndState, Job, SlackAlertConfig};
     use crate::domain::services::get_notifier::MockGetNotifier;
-    use crate::infrastructure::notify::MockNotifyLateJob;
-    use crate::infrastructure::notify::NotifyLateJob;
+    use crate::infrastructure::notify::MockNotifier;
+    use crate::infrastructure::notify::Notifier;
     use crate::infrastructure::repositories::alert_config::MockGetByMonitors;
 
     use super::*;
@@ -301,7 +301,7 @@ mod tests {
             .once()
             .in_sequence(&mut sequence)
             .returning(|_| {
-                let mut mock_notifier = MockNotifyLateJob::new();
+                let mut mock_notifier = MockNotifier::new();
                 mock_notifier
                     .expect_notify_late_job()
                     .once()
@@ -311,14 +311,14 @@ mod tests {
                             && job.job_id == gen_uuid("01a92c6c-6803-409d-b675-022fff62575a")
                     })
                     .returning(|_, _, _| Ok(()));
-                Box::new(mock_notifier) as Box<dyn NotifyLateJob + Sync + Send>
+                Box::new(mock_notifier) as Box<dyn Notifier + Sync + Send>
             });
         mock_get_notifier
             .expect_get_notifier()
             .once()
             .in_sequence(&mut sequence)
             .returning(|_| {
-                let mut mock_notifier = MockNotifyLateJob::new();
+                let mut mock_notifier = MockNotifier::new();
                 mock_notifier
                     .expect_notify_late_job()
                     .once()
@@ -328,14 +328,14 @@ mod tests {
                             && job.job_id == gen_uuid("3b9f5a89-ebc2-49bf-a9dd-61f52f7a3fa0")
                     })
                     .returning(|_, _, _| Ok(()));
-                Box::new(mock_notifier) as Box<dyn NotifyLateJob + Sync + Send>
+                Box::new(mock_notifier) as Box<dyn Notifier + Sync + Send>
             });
         mock_get_notifier
             .expect_get_notifier()
             .once()
             .in_sequence(&mut sequence)
             .returning(|_| {
-                let mut mock_notifier = MockNotifyLateJob::new();
+                let mut mock_notifier = MockNotifier::new();
                 mock_notifier
                     .expect_notify_late_job()
                     .once()
@@ -345,7 +345,7 @@ mod tests {
                             && job.job_id == gen_uuid("9d90c314-5120-400e-bf03-e6363689f985")
                     })
                     .returning(|_, _, _| Ok(()));
-                Box::new(mock_notifier) as Box<dyn NotifyLateJob + Sync + Send>
+                Box::new(mock_notifier) as Box<dyn Notifier + Sync + Send>
             });
 
         let mut service = ProcessLateJobsService::new(
@@ -426,7 +426,7 @@ mod tests {
             .once()
             .in_sequence(&mut sequence)
             .returning(|_| {
-                let mut mock_notifier = MockNotifyLateJob::new();
+                let mut mock_notifier = MockNotifier::new();
                 mock_notifier
                     .expect_notify_late_job()
                     .once()
@@ -436,14 +436,14 @@ mod tests {
                             && job.job_id == gen_uuid("01a92c6c-6803-409d-b675-022fff62575a")
                     })
                     .returning(|_, _, _| Ok(()));
-                Box::new(mock_notifier) as Box<dyn NotifyLateJob + Sync + Send>
+                Box::new(mock_notifier) as Box<dyn Notifier + Sync + Send>
             });
         mock_get_notifier
             .expect_get_notifier()
             .once()
             .in_sequence(&mut sequence)
             .returning(|_| {
-                let mut mock_notifier = MockNotifyLateJob::new();
+                let mut mock_notifier = MockNotifier::new();
                 mock_notifier
                     .expect_notify_late_job()
                     .once()
@@ -453,14 +453,14 @@ mod tests {
                             && job.job_id == gen_uuid("3b9f5a89-ebc2-49bf-a9dd-61f52f7a3fa0")
                     })
                     .returning(|_, _, _| Err(Error::NotifyError("Failed to notify".to_owned())));
-                Box::new(mock_notifier) as Box<dyn NotifyLateJob + Sync + Send>
+                Box::new(mock_notifier) as Box<dyn Notifier + Sync + Send>
             });
         mock_get_notifier
             .expect_get_notifier()
             .once()
             .in_sequence(&mut sequence)
             .returning(|_| {
-                let mut mock_notifier = MockNotifyLateJob::new();
+                let mut mock_notifier = MockNotifier::new();
                 mock_notifier
                     .expect_notify_late_job()
                     .once()
@@ -470,7 +470,7 @@ mod tests {
                             && job.job_id == gen_uuid("9d90c314-5120-400e-bf03-e6363689f985")
                     })
                     .returning(|_, _, _| Ok(()));
-                Box::new(mock_notifier) as Box<dyn NotifyLateJob + Sync + Send>
+                Box::new(mock_notifier) as Box<dyn Notifier + Sync + Send>
             });
 
         let mut service = ProcessLateJobsService::new(

--- a/api/src/domain/services/get_notifier.rs
+++ b/api/src/domain/services/get_notifier.rs
@@ -2,7 +2,7 @@
 use mockall::automock;
 
 use crate::domain::models::{AlertConfig, AlertType};
-use crate::infrastructure::notify::{slack::SlackNotifier, NotifyLateJob};
+use crate::infrastructure::notify::{slack::SlackNotifier, Notifier};
 
 /// Retrieve a notifier for a given alert configuration.
 #[cfg_attr(test, automock)]
@@ -12,7 +12,7 @@ pub trait GetNotifier {
     /// Note the Notifier returned is a trait object, so it can be used to notify late jobs without
     /// knowing the concrete type of the notifier. It must also be `Sync` and `Send` to be used in
     /// async contexts.
-    fn get_notifier(&self, alert_config: &AlertConfig) -> Box<dyn NotifyLateJob + Sync + Send>;
+    fn get_notifier(&self, alert_config: &AlertConfig) -> Box<dyn Notifier + Sync + Send>;
 }
 
 /// A service that retrieves a notifier for a given alert configuration.
@@ -33,7 +33,7 @@ impl Default for GetNotifierService {
 
 impl GetNotifier for GetNotifierService {
     /// Retrieve a notifier for a given alert configuration.
-    fn get_notifier(&self, alert_config: &AlertConfig) -> Box<dyn NotifyLateJob + Sync + Send> {
+    fn get_notifier(&self, alert_config: &AlertConfig) -> Box<dyn Notifier + Sync + Send> {
         match &alert_config.type_ {
             AlertType::Slack(config) => {
                 Box::new(SlackNotifier::new(&config.token, &config.channel))

--- a/api/src/infrastructure/notify/mod.rs
+++ b/api/src/infrastructure/notify/mod.rs
@@ -11,7 +11,7 @@ use crate::errors::Error;
 
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub trait NotifyLateJob {
+pub trait Notifier {
     async fn notify_late_job(
         &mut self,
         monitor_id: &Uuid,

--- a/api/src/infrastructure/notify/mod.rs
+++ b/api/src/infrastructure/notify/mod.rs
@@ -6,16 +6,25 @@ use uuid::Uuid;
 #[cfg(test)]
 use mockall::automock;
 
-use crate::domain::models::Job;
+use crate::domain::models::{AlertConfig, Job};
 use crate::errors::Error;
 
+/// Notify that a job is late or that it has errored - or send a test notification.
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait Notifier {
+    /// Notify that a job is late.
     async fn notify_late_job(
         &mut self,
         monitor_id: &Uuid,
         monitor_name: &str,
         late_job: &Job,
+    ) -> Result<(), Error>;
+
+    /// Send a test notification.
+    async fn test_notification(
+        &mut self,
+        alert_config: &AlertConfig,
+        user: &str,
     ) -> Result<(), Error>;
 }

--- a/api/src/infrastructure/notify/slack/integration.rs
+++ b/api/src/infrastructure/notify/slack/integration.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::domain::models::Job;
 use crate::errors::Error;
-use crate::infrastructure::notify::NotifyLateJob;
+use crate::infrastructure::notify::Notifier;
 
 use super::messages::LateJobMessage;
 
@@ -46,7 +46,7 @@ impl SlackNotifier {
 }
 
 #[async_trait]
-impl NotifyLateJob for SlackNotifier {
+impl Notifier for SlackNotifier {
     async fn notify_late_job(
         &mut self,
         monitor_id: &Uuid,

--- a/api/src/infrastructure/notify/slack/integration.rs
+++ b/api/src/infrastructure/notify/slack/integration.rs
@@ -2,11 +2,11 @@ use async_trait::async_trait;
 use slack_morphism::prelude::*;
 use uuid::Uuid;
 
-use crate::domain::models::Job;
+use crate::domain::models::{AlertConfig, Job};
 use crate::errors::Error;
 use crate::infrastructure::notify::Notifier;
 
-use super::messages::LateJobMessage;
+use super::messages::{LateJobMessage, TestMessage};
 
 /// Slack notifier for late jobs.
 ///
@@ -59,6 +59,14 @@ impl Notifier for SlackNotifier {
             job: late_job,
         })
         .await
+    }
+
+    async fn test_notification(
+        &mut self,
+        alert_config: &AlertConfig,
+        user: &str,
+    ) -> Result<(), Error> {
+        self.send_message(TestMessage { alert_config, user }).await
     }
 }
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -53,6 +53,7 @@ pub fn rocket() -> Rocket<Build> {
                 alert_config::update_alert_config,
                 alert_config::delete_alert_config,
                 alert_config::get_alert_configs_for_monitor,
+                alert_config::test_alert_config,
             ],
         )
         .mount("/api/v1/docs", FileServer::from("./docs"))


### PR DESCRIPTION
Relates to #24 

Implement the `POST /api/v1/alert-configs/{alert_config_id}/test` API route.

Just error alerts to go 🙏 