### PR TITLE
Feat/get monitors with failed jobs

### DIFF
--- a/api/src/infrastructure/repositories/monitor/mod.rs
+++ b/api/src/infrastructure/repositories/monitor/mod.rs
@@ -10,8 +10,13 @@ use crate::errors::Error;
 
 pub use repo::MonitorRepository;
 
+/// Get Monitors with jobs that are late or have finished with an error.
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait GetWithErroneousJobs {
+    /// Get Monitors with jobs that are late or have finished with an error.
+    ///
+    /// Note that this method must not return Monitors that have erroneous jobs that have already
+    /// been alerted on.
     async fn get_with_erroneous_jobs(&mut self) -> Result<Vec<Monitor>, Error>;
 }

--- a/api/src/infrastructure/repositories/monitor/mod.rs
+++ b/api/src/infrastructure/repositories/monitor/mod.rs
@@ -12,6 +12,6 @@ pub use repo::MonitorRepository;
 
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub trait GetWithLateJobs {
-    async fn get_with_late_jobs(&mut self) -> Result<Vec<Monitor>, Error>;
+pub trait GetWithErroneousJobs {
+    async fn get_with_erroneous_jobs(&mut self) -> Result<Vec<Monitor>, Error>;
 }

--- a/api/src/infrastructure/repositories/monitor/repo.rs
+++ b/api/src/infrastructure/repositories/monitor/repo.rs
@@ -46,6 +46,10 @@ impl<'a> MonitorRepository<'a> {
 #[async_trait]
 #[allow(clippy::needless_lifetimes)] // This is needed for the lifetime of the pool
 impl<'a> GetWithErroneousJobs for MonitorRepository<'a> {
+    /// Get Monitors with jobs that are late or have finished with an error.
+    ///
+    /// Note that this method will not return Monitors that have erroneous jobs that have already
+    /// been alerted on.
     async fn get_with_erroneous_jobs(&mut self) -> Result<Vec<Monitor>, Error> {
         let mut connection = get_connection(self.pool).await?;
         let (monitor_datas, job_datas) = connection

--- a/api/src/infrastructure/repositories/monitor/repo.rs
+++ b/api/src/infrastructure/repositories/monitor/repo.rs
@@ -15,7 +15,7 @@ use crate::infrastructure::db_schema::job;
 use crate::infrastructure::db_schema::monitor;
 use crate::infrastructure::models::job::JobData;
 use crate::infrastructure::models::monitor::MonitorData;
-use crate::infrastructure::repositories::monitor::GetWithLateJobs;
+use crate::infrastructure::repositories::monitor::GetWithErroneousJobs;
 use crate::infrastructure::repositories::Repository;
 
 pub struct MonitorRepository<'a> {
@@ -45,8 +45,8 @@ impl<'a> MonitorRepository<'a> {
 
 #[async_trait]
 #[allow(clippy::needless_lifetimes)] // This is needed for the lifetime of the pool
-impl<'a> GetWithLateJobs for MonitorRepository<'a> {
-    async fn get_with_late_jobs(&mut self) -> Result<Vec<Monitor>, Error> {
+impl<'a> GetWithErroneousJobs for MonitorRepository<'a> {
+    async fn get_with_erroneous_jobs(&mut self) -> Result<Vec<Monitor>, Error> {
         let mut connection = get_connection(self.pool).await?;
         let (monitor_datas, job_datas) = connection
             .transaction::<(Vec<MonitorData>, Vec<JobData>), DieselError, _>(|conn| {

--- a/api/src/infrastructure/repositories/monitor/repo.rs
+++ b/api/src/infrastructure/repositories/monitor/repo.rs
@@ -55,19 +55,23 @@ impl<'a> GetWithErroneousJobs for MonitorRepository<'a> {
         let (monitor_datas, job_datas) = connection
             .transaction::<(Vec<MonitorData>, Vec<JobData>), DieselError, _>(|conn| {
                 Box::pin(async move {
-                    let in_progress_condition =
+                    let running_late_condition =
                         job::end_time.is_null().and(now.gt(job::max_end_time));
-                    let finished_condition = job::end_time
+                    let finished_late_condition = job::end_time
                         .is_not_null()
                         .and(job::end_time.assume_not_null().gt(job::max_end_time));
 
-                    // Get all late jobs.
+                    // Get all late and errored jobs.
                     let monitor_datas: Vec<MonitorData> = monitor::table
                         .inner_join(job::table)
                         .filter(
-                            job::late_alert_sent
+                            (job::late_alert_sent
                                 .eq(false)
-                                .and(in_progress_condition.or(finished_condition)),
+                                .and(running_late_condition.or(finished_late_condition)))
+                            .or(job::error_alert_sent
+                                .eq(false)
+                                .and(job::end_time.is_not_null())
+                                .and(job::succeeded.eq(false))),
                         )
                         .select(MonitorData::as_select())
                         .distinct_on(monitor::monitor_id)

--- a/api/tests/common/seeds.rs
+++ b/api/tests/common/seeds.rs
@@ -57,7 +57,7 @@ pub fn job_seeds() -> Vec<JobData> {
             monitor_id: gen_uuid("c1bf0515-df39-448b-aa95-686360a33b36"),
             start_time: gen_datetime("2024-05-01T00:00:00.000"),
             max_end_time: gen_datetime("2024-05-01T00:40:00.000"),
-            end_time: Some(gen_datetime("2024-05-01T01:39:00.000")),
+            end_time: Some(gen_datetime("2024-05-01T00:39:00.000")),
             succeeded: Some(false),
             output: Some("Could not connect to database".to_string()),
             late_alert_sent: false,

--- a/api/tests/monitor_repo_test.rs
+++ b/api/tests/monitor_repo_test.rs
@@ -9,7 +9,9 @@ use test_utils::{gen_datetime, gen_uuid};
 use cron_mon_api::domain::models::Monitor;
 use cron_mon_api::errors::Error;
 use cron_mon_api::infrastructure::models::{job::JobData, monitor::MonitorData};
-use cron_mon_api::infrastructure::repositories::monitor::{GetWithLateJobs, MonitorRepository};
+use cron_mon_api::infrastructure::repositories::monitor::{
+    GetWithErroneousJobs, MonitorRepository,
+};
 use cron_mon_api::infrastructure::repositories::Repository;
 
 use common::{infrastructure, Infrastructure};
@@ -79,11 +81,11 @@ async fn test_get(#[future] infrastructure: Infrastructure) {
 
 #[rstest]
 #[tokio::test]
-async fn test_get_with_late_jobs(#[future] infrastructure: Infrastructure) {
+async fn test_get_with_erroneous_jobs(#[future] infrastructure: Infrastructure) {
     let infra = infrastructure.await;
     let mut repo = MonitorRepository::new(&infra.pool);
 
-    let monitors_with_late_jobs = repo.get_with_late_jobs().await.unwrap();
+    let monitors_with_late_jobs = repo.get_with_erroneous_jobs().await.unwrap();
     let mut names: Vec<String> = monitors_with_late_jobs
         .iter()
         .map(|monitor| monitor.name.clone())


### PR DESCRIPTION
Related to #24 

Need to be able to retrieve Monitors with jobs that have finished with an error, as well as late jobs (as we already retrieve).